### PR TITLE
fix: restyle calculator add button

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -628,16 +628,55 @@ p, li, a { overflow-wrap: anywhere; word-break: break-word; }
 #cal-total.h2{ margin:0 }
 
 /* Kalkulator result box */
-.calc-box{ display:flex; align-items:center; justify-content:space-between; gap:var(--space-md); padding:var(--space-md); border:1px solid var(--border); border-radius:12px; background:var(--bg-tertiary); box-shadow: 0 10px 26px rgba(1,61,57,.06) }
+.calc-grid{ display:grid; gap:var(--space-md); grid-template-columns:repeat(3,minmax(0,1fr)); align-items:end }
+.calc-field{ display:flex; flex-direction:column; gap:.55rem }
+.calc-field--weight{ gap:.7rem }
+.calc-field--weight .calc-add-btn{ margin-top:.2rem }
+.calc-add-btn{ width:100%; border-radius:12px; white-space:nowrap; justify-content:center }
+.calc-box{ display:flex; flex-direction:column; gap:var(--space-lg); padding:var(--space-md); border:1px solid var(--border); border-radius:12px; background:var(--bg-tertiary); box-shadow:0 10px 26px rgba(1,61,57,.06) }
+.calc-current{ display:flex; flex-direction:column; gap:.45rem; padding:var(--space-md); border-radius:12px; border:1px solid var(--border-subtle); background:var(--paper); box-shadow:0 8px 22px rgba(1,61,57,.08) }
 .calc-info{ line-height:1.2 }
+.calc-summary{ display:flex; align-items:center; justify-content:space-between; gap:var(--space-md); flex-wrap:wrap; padding:var(--space-md); border:1px solid var(--border-subtle); border-radius:12px; background:var(--paper) }
 .calc-label{ color:var(--text-secondary); font-weight:600; letter-spacing:.02em }
-.calc-amount{ font-family:"Playfair Display",serif; font-weight:700; font-size:clamp(1.6rem, 1.2vw + 1rem, 2rem); color:var(--accent-green); margin:.3rem 0 .55rem }
+.calc-count{ color:var(--text-secondary); font-size:.95rem; font-weight:600 }
+.calc-amount{ font-family:"Playfair Display",serif; font-weight:700; font-size:clamp(1.6rem, 1.2vw + 1rem, 2rem); color:var(--accent-green); margin:.2rem 0 .4rem }
 .calc-note{ color:var(--text-muted); font-size:.95rem }
+.calc-note--sub{ margin-top:.25rem; font-size:.9rem }
+.calc-items{ border:1px solid var(--border-subtle); border-radius:12px; background:var(--paper); padding:var(--space-md) }
+.calc-empty{ margin:0; color:var(--text-muted); font-size:.95rem; line-height:1.5 }
+.calc-table-wrap{ margin-top:.8rem; overflow-x:auto }
+.calc-table{ width:100%; min-width:360px; border-collapse:collapse }
+.calc-table th, .calc-table td{ padding:.65rem .75rem; font-size:.95rem; text-align:left; border-bottom:1px solid var(--border-subtle) }
+.calc-table th:nth-child(2), .calc-table td:nth-child(2),
+.calc-table th:nth-child(3), .calc-table td:nth-child(3){ text-align:right; white-space:nowrap }
+.calc-table th:last-child, .calc-table td:last-child{ text-align:center; width:1% }
+.calc-table tbody tr:last-child td{ border-bottom:none }
+.calc-item-name{ font-weight:600; color:var(--text-primary) }
+.calc-item-meta{ color:var(--text-muted); font-size:.85rem; margin-top:.15rem }
+.calc-weight-field{ display:flex; align-items:center; justify-content:flex-end; gap:.35rem }
+.calc-weight-field input{ width:5.75rem; padding:.45rem .6rem; border-radius:8px; border:1px solid var(--border-subtle); background:var(--paper); color:var(--text-primary); font-size:.95rem; text-align:right; font-family:inherit }
+.calc-weight-field input:focus-visible{ outline:2px solid var(--accent-green); outline-offset:2px; border-color:var(--accent-green) }
+.calc-weight-suffix{ color:var(--text-muted); font-size:.85rem }
+.calc-remove{ border:0; background:none; color:var(--text-muted); font-size:.9rem; font-weight:600; cursor:pointer; padding:.2rem .4rem; border-radius:8px }
+.calc-remove:hover, .calc-remove:focus-visible{ color:var(--accent-green); background:rgba(1,61,57,.08) }
+.calc-remove:focus-visible{ outline:2px solid var(--accent-green); outline-offset:2px }
 /* Prevent calculator button from becoming circle on narrow screens */
 .calc-box .btn{ white-space:nowrap; border-radius:12px }
-@media (max-width: 520px){
-  .calc-box{ flex-direction:column; align-items:stretch }
-  .calc-box .btn{ width:100%; text-align:center }
+.calc-summary .btn{ flex-shrink:0 }
+.calc-current .calc-note{ margin-bottom:0 }
+@media (max-width: 900px){
+  .calc-grid{ grid-template-columns:repeat(2,minmax(0,1fr)) }
+}
+@media (max-width: 640px){
+  .calc-grid{ grid-template-columns:1fr }
+  .calc-box{ gap:var(--space-md) }
+  .calc-current{ padding:calc(var(--space-sm) + var(--space-xs)) }
+  .calc-items{ padding:calc(var(--space-sm) + var(--space-xs)) }
+  .calc-summary{ flex-direction:column; align-items:stretch }
+  .calc-summary .btn{ width:100%; text-align:center }
+}
+@media (max-width: 540px){
+  .calc-table{ min-width:0 }
 }
 
 /* CTA section styling moved from inline */

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -634,7 +634,7 @@ p, li, a { overflow-wrap: anywhere; word-break: break-word; }
 #cal-total.h2{ margin:0 }
 
 /* Kalkulator result box */
-.calc-grid{ display:grid; gap:var(--space-md); grid-template-columns:repeat(3,minmax(0,1fr)); align-items:end }
+.calc-grid{ display:grid; gap:var(--space-md); grid-template-columns:repeat(3,minmax(0,1fr)); align-items:flex-start }
 .calc-field{ display:flex; flex-direction:column; gap:.55rem }
 .calc-field--weight{ gap:.7rem }
 .calc-field--weight .calc-add-btn{ margin-top:.2rem }

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -46,6 +46,9 @@ summary:focus-visible{outline:3px solid var(--focus-ring-strong);outline-offset:
     --text-muted: #4a5d5a;
     --accent-green: #0E4D47;
     --accent-green-light: #335e5a;
+    --calc-add-bg: #0E4D47;
+    --calc-add-bg-hover: #0B3D39;
+    --calc-add-text: #ffffff;
 }
 
 /* Dark mode theme */
@@ -58,6 +61,9 @@ summary:focus-visible{outline:3px solid var(--focus-ring-strong);outline-offset:
     --text-muted: #7a8a87;
     --accent-green: var(--gold-2);
     --accent-green-light: var(--gold);
+    --calc-add-bg: rgba(212,175,55,.95);
+    --calc-add-bg-hover: var(--gold);
+    --calc-add-text: #013D39;
     --border: #2a3a37;
     --border-subtle: #1f2e2b;
     --muted: #a8b5b3;
@@ -632,7 +638,25 @@ p, li, a { overflow-wrap: anywhere; word-break: break-word; }
 .calc-field{ display:flex; flex-direction:column; gap:.55rem }
 .calc-field--weight{ gap:.7rem }
 .calc-field--weight .calc-add-btn{ margin-top:.2rem }
-.calc-add-btn{ width:100%; border-radius:12px; white-space:nowrap; justify-content:center }
+.calc-add-btn{
+  width:100%;
+  border-radius:12px;
+  white-space:nowrap;
+  justify-content:center;
+  background:var(--calc-add-bg);
+  color:var(--calc-add-text);
+  border-color:transparent;
+  box-shadow:0 12px 24px rgba(1,61,57,.12);
+  transition:background .2s ease, box-shadow .2s ease, transform .2s ease;
+}
+.calc-add-btn:hover{
+  background:var(--calc-add-bg-hover);
+  box-shadow:0 16px 32px rgba(1,61,57,.18);
+  transform:translateY(-1px);
+}
+.calc-add-btn:active{
+  transform:translateY(0);
+}
 .calc-box{ display:flex; flex-direction:column; gap:var(--space-lg); padding:var(--space-md); border:1px solid var(--border); border-radius:12px; background:var(--bg-tertiary); box-shadow:0 10px 26px rgba(1,61,57,.06) }
 .calc-current{ display:flex; flex-direction:column; gap:.45rem; padding:var(--space-md); border-radius:12px; border:1px solid var(--border-subtle); background:var(--paper); box-shadow:0 8px 22px rgba(1,61,57,.08) }
 .calc-info{ line-height:1.2 }

--- a/assets/js/main.test.js
+++ b/assets/js/main.test.js
@@ -82,7 +82,7 @@ describe('main.js behaviours', () => {
         </div>
         <div class="calc-field calc-field--weight">
           <input id="cal-berat" value="3" />
-          <button id="cal-add" type="button" class="calc-add-btn">Tambah</button>
+          <button id="cal-add" type="button" class="btn calc-add-btn">Tambah</button>
         </div>
       </div>
       <div class="calc-box">

--- a/harga/index.html
+++ b/harga/index.html
@@ -176,7 +176,7 @@
               <div class="calc-field calc-field--weight">
                 <label for="cal-berat" class="h3">Berat (gram)</label>
                 <input id="cal-berat" type="number" min="0" step="0.01" value="1" class="form-control converter-input" />
-                <button id="cal-add" type="button" class="btn btn-ghost calc-add-btn">Tambah ke Daftar</button>
+                <button id="cal-add" type="button" class="btn calc-add-btn">Tambah ke Daftar</button>
               </div>
             </div>
             <div class="calc-box mt-10">

--- a/harga/index.html
+++ b/harga/index.html
@@ -138,19 +138,19 @@
           <div class="accent-title">Kalkulator Emas</div>
           <h2 class="h2">Estimasi Buyback Hari Ini</h2>
           <div class="card pad-1">
-            <div class="grid grid-3 gap-1">
-              <div>
+            <div class="calc-grid">
+              <div class="calc-field">
                 <label for="cal-cat" class="h3">Kategori</label>
-                <select id="cal-cat" class="form-control">
+                <select id="cal-cat" class="form-control converter-select">
                   <option value="lm_baru">Logam Mulia (LM) Baru</option>
                   <option value="lm_lama">Logam Mulia (LM) Lama</option>
                   <option value="perhiasan_24">Perhiasan 24K</option>
                   <option value="perhiasan_sub">Perhiasan &lt;24K</option>
                 </select>
               </div>
-              <div>
+              <div class="calc-field">
                 <label for="cal-kadar" class="h3">Kadar</label>
-                <select id="cal-kadar" class="form-control">
+                <select id="cal-kadar" class="form-control converter-select">
                   <option value="24">24K</option>
                   <option value="23">23K</option>
                   <option value="22">22K</option>
@@ -173,18 +173,43 @@
                   <option value="5">5K</option>
                 </select>
               </div>
-              <div>
+              <div class="calc-field calc-field--weight">
                 <label for="cal-berat" class="h3">Berat (gram)</label>
-                <input id="cal-berat" type="number" min="0" step="0.01" value="1" class="form-control" />
+                <input id="cal-berat" type="number" min="0" step="0.01" value="1" class="form-control converter-input" />
+                <button id="cal-add" type="button" class="btn btn-ghost calc-add-btn">Tambah ke Daftar</button>
               </div>
             </div>
             <div class="calc-box mt-10">
-              <div class="calc-info">
-                <div class="calc-label">Perkiraan total</div>
-                <div id="cal-total" class="calc-amount" role="status" aria-live="polite" aria-atomic="true" aria-describedby="cal-note">Rp 0</div>
-                <div id="cal-note" class="calc-note">Estimasi mengikuti harga dasar hari ini; hasil akhir tergantung kondisi barang.</div>
+              <div class="calc-current">
+                <div class="calc-label">Estimasi item ini</div>
+                <div id="cal-current" class="calc-amount" role="status" aria-live="polite" aria-atomic="true">Rp 0</div>
+                <div class="calc-note calc-note--sub">Atur kategori, kadar, dan berat lalu ketuk tombol tambah. Berat bisa disesuaikan langsung di daftar.</div>
               </div>
-              <a id="wa-prefill" class="btn btn-gold" href="https://wa.me/6285591088503" target="_blank" rel="noopener noreferrer" data-track="wa-kalkulator">Kirim Detail via WhatsApp</a>
+              <div class="calc-items" aria-live="polite" aria-atomic="false">
+                <div id="cal-empty" class="calc-empty">Belum ada item dalam daftar. Gunakan tombol tambah di formulir atau ikon plus pada tabel harga.</div>
+                <div id="cal-table-wrap" class="calc-table-wrap" hidden>
+                  <table class="calc-table">
+                    <thead>
+                      <tr>
+                        <th scope="col">Barang</th>
+                        <th scope="col">Berat (gram)</th>
+                        <th scope="col">Estimasi</th>
+                        <th scope="col"><span class="sr-only">Aksi</span></th>
+                      </tr>
+                    </thead>
+                    <tbody id="cal-items-body"></tbody>
+                  </table>
+                </div>
+              </div>
+              <div class="calc-summary">
+                <div class="calc-info">
+                  <div class="calc-label">Perkiraan total</div>
+                  <div id="cal-count" class="calc-count">0 barang</div>
+                  <div id="cal-total" class="calc-amount" role="status" aria-live="polite" aria-atomic="true" aria-describedby="cal-note">Rp 0</div>
+                  <div id="cal-note" class="calc-note">Estimasi mengikuti harga dasar hari ini; hasil akhir tergantung kondisi barang.</div>
+                </div>
+                <a id="wa-prefill" class="btn btn-gold" href="https://wa.me/6285591088503" target="_blank" rel="noopener noreferrer" data-track="wa-kalkulator">Kirim Detail via WhatsApp</a>
+              </div>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -299,7 +299,7 @@
               <div class="calc-field calc-field--weight">
                 <label for="cal-berat" class="h3">Berat (gram)</label>
                 <input id="cal-berat" type="number" min="0" step="0.01" value="1" class="form-control converter-input" />
-                <button id="cal-add" type="button" class="btn btn-ghost calc-add-btn">Tambah ke Daftar</button>
+                <button id="cal-add" type="button" class="btn calc-add-btn">Tambah ke Daftar</button>
               </div>
             </div>
             <div class="calc-box mt-10">

--- a/index.html
+++ b/index.html
@@ -261,8 +261,8 @@
           <div class="accent-title">Kalkulator Emas</div>
           <h2 class="h2">Estimasi Buyback Hari Ini</h2>
           <div class="card pad-1">
-            <div class="grid grid-3 gap-1">
-              <div>
+            <div class="calc-grid">
+              <div class="calc-field">
                 <label for="cal-cat" class="h3">Kategori</label>
                 <select id="cal-cat" class="form-control converter-select">
                   <option value="lm_baru">Logam Mulia (LM) Baru</option>
@@ -271,7 +271,7 @@
                   <option value="perhiasan_sub">Perhiasan &lt;24K</option>
                 </select>
               </div>
-              <div>
+              <div class="calc-field">
                 <label for="cal-kadar" class="h3">Kadar</label>
                 <select id="cal-kadar" class="form-control converter-select">
                   <option value="24">24K</option>
@@ -296,18 +296,43 @@
                   <option value="5">5K</option>
                 </select>
               </div>
-              <div>
+              <div class="calc-field calc-field--weight">
                 <label for="cal-berat" class="h3">Berat (gram)</label>
                 <input id="cal-berat" type="number" min="0" step="0.01" value="1" class="form-control converter-input" />
+                <button id="cal-add" type="button" class="btn btn-ghost calc-add-btn">Tambah ke Daftar</button>
               </div>
             </div>
             <div class="calc-box mt-10">
-              <div class="calc-info">
-                <div class="calc-label">Perkiraan total</div>
-                <div id="cal-total" class="calc-amount" role="status" aria-live="polite" aria-atomic="true" aria-describedby="cal-note">Rp 0</div>
-                <div id="cal-note" class="calc-note">Estimasi mengikuti harga dasar hari ini; hasil akhir tergantung kondisi barang.</div>
+              <div class="calc-current">
+                <div class="calc-label">Estimasi item ini</div>
+                <div id="cal-current" class="calc-amount" role="status" aria-live="polite" aria-atomic="true">Rp 0</div>
+                <div class="calc-note calc-note--sub">Atur kategori, kadar, dan berat lalu ketuk tombol tambah. Berat bisa disesuaikan langsung di daftar.</div>
               </div>
-              <a id="wa-prefill" class="btn btn-gold" href="https://wa.me/6285591088503" target="_blank" rel="noopener noreferrer" data-track="wa-kalkulator">Kirim Detail via WhatsApp</a>
+              <div class="calc-items" aria-live="polite" aria-atomic="false">
+                <div id="cal-empty" class="calc-empty">Belum ada item dalam daftar. Gunakan tombol tambah di formulir atau ikon plus pada tabel harga.</div>
+                <div id="cal-table-wrap" class="calc-table-wrap" hidden>
+                  <table class="calc-table">
+                    <thead>
+                      <tr>
+                        <th scope="col">Barang</th>
+                        <th scope="col">Berat (gram)</th>
+                        <th scope="col">Estimasi</th>
+                        <th scope="col"><span class="sr-only">Aksi</span></th>
+                      </tr>
+                    </thead>
+                    <tbody id="cal-items-body"></tbody>
+                  </table>
+                </div>
+              </div>
+              <div class="calc-summary">
+                <div class="calc-info">
+                  <div class="calc-label">Perkiraan total</div>
+                  <div id="cal-count" class="calc-count">0 barang</div>
+                  <div id="cal-total" class="calc-amount" role="status" aria-live="polite" aria-atomic="true" aria-describedby="cal-note">Rp 0</div>
+                  <div id="cal-note" class="calc-note">Estimasi mengikuti harga dasar hari ini; hasil akhir tergantung kondisi barang.</div>
+                </div>
+                <a id="wa-prefill" class="btn btn-gold" href="https://wa.me/6285591088503" target="_blank" rel="noopener noreferrer" data-track="wa-kalkulator">Kirim Detail via WhatsApp</a>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- enable editing calculator items directly in the list with weight inputs, live totals, and WhatsApp updates
- refresh calculator copy and styling so the inline weight controls and repositioned add button stay readable across desktop and mobile layouts
- extend the calculator unit tests to cover editing behaviour and the updated DOM structure

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68cec6fbfd588330932144c8b6fe38c4