### PR TITLE
Restore hostess CTA artwork fallback

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -508,6 +508,23 @@ p, li, a { overflow-wrap: anywhere; word-break: break-word; }
   background-position:center;
   background-size:cover;
   background-repeat:no-repeat;
+  overflow:hidden;
+}
+.bg-hostess__fallback{
+  position:absolute;
+  inset:0;
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  display:block;
+  pointer-events:none;
+  border-radius:inherit;
+  z-index:0;
+  transition:opacity .4s ease;
+}
+.bg-hostess > :not(.bg-hostess__fallback){
+  position:relative;
+  z-index:2;
 }
 .bg-hostess::before{
   content:"";
@@ -518,11 +535,16 @@ p, li, a { overflow-wrap: anywhere; word-break: break-word; }
     linear-gradient(135deg, rgba(1,61,57,.85), rgba(1,61,57,.62));
   transition:opacity .4s ease;
   pointer-events:none;
+  z-index:1;
 }
 .bg-hostess.bg-loaded{
   background-color:transparent;
 }
 .bg-hostess.bg-loaded::before{
+  opacity:0;
+}
+.bg-hostess.bg-loaded .bg-hostess__fallback,
+.bg-hostess__fallback.is-hidden{
   opacity:0;
 }
 .bg-hostess.bg-error::before{

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -156,6 +156,17 @@
       try{ el.style.backgroundImage = 'url(' + JSON.stringify(src) + ')'; }
       catch(_){ el.style.backgroundImage = 'url("' + src.replace(/"/g, '\\"') + '")'; }
       el.classList.add('bg-loaded');
+      const fallback = el.querySelector('.bg-hostess__fallback');
+      if(fallback){
+        fallback.classList.add('is-hidden');
+        const cleanup = function(){
+          if(fallback && fallback.parentNode){
+            fallback.parentNode.removeChild(fallback);
+          }
+        };
+        fallback.addEventListener('transitionend', cleanup, { once: true });
+        setTimeout(cleanup, 700);
+      }
     }, { once: true });
     img.addEventListener('error', function(){ el.classList.add('bg-error'); }, { once: true });
     img.src = src;

--- a/harga/index.html
+++ b/harga/index.html
@@ -231,7 +231,9 @@
               <a class="btn btn-ghost" href="tel:+6285591088503" data-track="tel-cta-harga">Telepon</a>
             </div>
           </div>
-          <div class="card bg-hostess pad-1" role="img" aria-label="Ilustrasi customer service" data-bg="/assets/img/wm.webp"></div>
+          <div class="card bg-hostess pad-1" role="img" aria-label="Ilustrasi customer service" data-bg="/assets/img/wm.webp">
+            <img class="bg-hostess__fallback" src="/assets/img/wm.webp" alt="" loading="lazy" decoding="async" aria-hidden="true"/>
+          </div>
         </div>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -539,7 +539,9 @@
               <a class="btn btn-ghost" href="tel:+6285591088503" data-track="tel-cta">Telepon</a>
             </div>
           </div>
-          <div class="card bg-hostess pad-1" role="img" aria-label="Ilustrasi customer service" data-bg="assets/img/wm.webp"></div>
+          <div class="card bg-hostess pad-1" role="img" aria-label="Ilustrasi customer service" data-bg="assets/img/wm.webp">
+            <img class="bg-hostess__fallback" src="assets/img/wm.webp" alt="" loading="lazy" decoding="async" aria-hidden="true"/>
+          </div>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- add a fallback `<img>` inside the hostess CTA card so the illustration renders even when JavaScript fails
- style the fallback image to sit beneath the gradient overlay and fade out when the lazy background finishes loading
- remove the fallback node after the lazy-loaded background image is applied to avoid duplicate content

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cf4b3114808330b277e95c8543e187