### PR TITLE
Move diamond guide under blog

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -37,6 +37,15 @@
     "publisher": {"@id": "https://sentralemas.com/#business"},
     "blogPost": [{
       "@type": "BlogPosting",
+      "@id": "https://sentralemas.com/blog/panduan-buyback-berlian/",
+      "headline": "Panduan Buyback Berlian: Kenali 4C, Bentuk, & Sertifikat",
+      "image": "https://sentralemas.com/assets/img/diamond.webp",
+      "datePublished": "2025-09-17",
+      "dateModified": "2025-09-17",
+      "author": {"@type": "Organization", "name": "Sentral Emas"},
+      "description": "Pelajari kualitas berlian, variasi bentuk populer, dan dokumen penting sebelum konsultasi buyback COD."
+    },{
+      "@type": "BlogPosting",
       "@id": "https://sentralemas.com/blog/keuntungan-jual-emas-cod/",
       "headline": "Keuntungan Jual Emas via COD yang Aman",
       "image": "https://sentralemas.com/assets/img/asset1.webp",
@@ -79,7 +88,7 @@
         <a itemprop="url" href="/#fitur"><span itemprop="name">Fitur</span></a>
         <a itemprop="url" href="/#diterima"><span itemprop="name">Yang Diterima</span></a>
         <a itemprop="url" href="/#harga"><span itemprop="name">Harga Buyback</span></a>
-        <a itemprop="url" href="/berlian/"><span itemprop="name">Panduan Berlian</span></a>
+        <a itemprop="url" href="/blog/panduan-buyback-berlian/"><span itemprop="name">Panduan Berlian</span></a>
         <a itemprop="url" href="/#kontak"><span itemprop="name">Kontak</span></a>
       </nav>
       <a class="btn btn-gold hamb" href="/#kontak">Hubungi</a>
@@ -93,6 +102,17 @@
         <p class="blog-lead">Kumpulan artikel, panduan, dan insight seputar jual beli emas, berlian, serta layanan COD aman oleh tim Sentral Emas.</p>
       </header>
       <div class="blog-grid">
+        <article class="blog-card">
+          <a class="blog-card__link" href="/blog/panduan-buyback-berlian/">
+            <span class="blog-card__badge">Panduan</span>
+            <h2 class="blog-card__title">Panduan Buyback Berlian: Pahami 4C &amp; Sertifikat</h2>
+            <p class="blog-card__excerpt">Pelajari kualitas berlian, bentuk populer, dan dokumen penting sebelum konsultasi buyback COD.</p>
+            <dl class="blog-card__meta">
+              <div><dt>Tanggal</dt><dd>17 September 2025</dd></div>
+              <div><dt>Durasi baca</dt><dd>±10 menit</dd></div>
+            </dl>
+          </a>
+        </article>
         <article class="blog-card">
           <a class="blog-card__link" href="/blog/panduan-menilai-keaslian-emas-sebelum-cod/">
             <span class="blog-card__badge">Panduan</span>

--- a/blog/keuntungan-jual-emas-cod/index.html
+++ b/blog/keuntungan-jual-emas-cod/index.html
@@ -81,7 +81,7 @@
         <a itemprop="url" href="/#fitur"><span itemprop="name">Fitur</span></a>
         <a itemprop="url" href="/#diterima"><span itemprop="name">Yang Diterima</span></a>
         <a itemprop="url" href="/#harga"><span itemprop="name">Harga Buyback</span></a>
-        <a itemprop="url" href="/berlian/"><span itemprop="name">Panduan Berlian</span></a>
+        <a itemprop="url" href="/blog/panduan-buyback-berlian/"><span itemprop="name">Panduan Berlian</span></a>
         <a itemprop="url" href="/blog/"><span itemprop="name">Blog</span></a>
         <a itemprop="url" href="/#kontak"><span itemprop="name">Kontak</span></a>
       </nav>

--- a/blog/panduan-buyback-berlian/index.html
+++ b/blog/panduan-buyback-berlian/index.html
@@ -70,7 +70,6 @@
           <a itemprop="url" href="/#fitur"><span itemprop="name">Fitur</span></a>
           <a itemprop="url" href="/#diterima"><span itemprop="name">Yang Diterima</span></a>
           <a itemprop="url" href="/harga/"><span itemprop="name">Harga Emas</span></a>
-          <a itemprop="url" href="/blog/panduan-buyback-berlian/" aria-current="page"><span itemprop="name">Panduan Berlian</span></a>
           <a itemprop="url" href="/blog/"><span itemprop="name">Blog</span></a>
           <a itemprop="url" href="/#kontak"><span itemprop="name">Kontak</span></a>
         </nav>
@@ -538,7 +537,6 @@
           <ul>
             <li><a href="/">Beranda</a></li>
             <li><a href="/harga/">Harga Buyback Emas</a></li>
-            <li><a href="/blog/panduan-buyback-berlian/" aria-current="page">Panduan Berlian</a></li>
             <li><a href="/blog/">Blog</a></li>
             <li><a href="/index.html#kontak">Kontak</a></li>
           </ul>

--- a/blog/panduan-buyback-berlian/index.html
+++ b/blog/panduan-buyback-berlian/index.html
@@ -24,14 +24,14 @@
     />
     <title>Panduan Berlian &amp; Buyback COD | Sentral Emas</title>
     <meta name="description" content="Pelajari 4C berlian, variasi bentuk populer, dan panduan sertifikat untuk buyback berlian COD di Sentral Emas."/>
-    <link rel="canonical" href="https://sentralemas.com/berlian/"/>
+    <link rel="canonical" href="https://sentralemas.com/blog/panduan-buyback-berlian/"/>
     <meta name="application-name" content="Sentral Emas"/>
     <meta name="apple-mobile-web-app-title" content="Sentral Emas"/>
     <meta property="og:locale" content="id_ID"/>
     <meta property="og:type" content="website"/>
     <meta property="og:title" content="Panduan Berlian &amp; Buyback COD | Sentral Emas"/>
     <meta property="og:description" content="Pelajari 4C berlian, variasi bentuk populer, dan panduan sertifikat untuk buyback berlian COD di Sentral Emas."/>
-    <meta property="og:url" content="https://sentralemas.com/berlian/"/>
+    <meta property="og:url" content="https://sentralemas.com/blog/panduan-buyback-berlian/"/>
     <meta property="og:site_name" content="Sentral Emas"/>
     <meta property="og:image" content="https://sentralemas.com/assets/icons/android-chrome-512x512.png"/>
     <meta property="og:image:alt" content="Logo Sentral Emas"/>
@@ -70,7 +70,7 @@
           <a itemprop="url" href="/#fitur"><span itemprop="name">Fitur</span></a>
           <a itemprop="url" href="/#diterima"><span itemprop="name">Yang Diterima</span></a>
           <a itemprop="url" href="/harga/"><span itemprop="name">Harga Emas</span></a>
-          <a itemprop="url" href="/berlian/" aria-current="page"><span itemprop="name">Panduan Berlian</span></a>
+          <a itemprop="url" href="/blog/panduan-buyback-berlian/" aria-current="page"><span itemprop="name">Panduan Berlian</span></a>
           <a itemprop="url" href="/blog/"><span itemprop="name">Blog</span></a>
           <a itemprop="url" href="/#kontak"><span itemprop="name">Kontak</span></a>
         </nav>
@@ -538,7 +538,7 @@
           <ul>
             <li><a href="/">Beranda</a></li>
             <li><a href="/harga/">Harga Buyback Emas</a></li>
-              <li><a href="/berlian/" aria-current="page">Panduan Berlian</a></li>
+            <li><a href="/blog/panduan-buyback-berlian/" aria-current="page">Panduan Berlian</a></li>
             <li><a href="/blog/">Blog</a></li>
             <li><a href="/index.html#kontak">Kontak</a></li>
           </ul>
@@ -565,7 +565,8 @@
         "@type": "BreadcrumbList",
         "itemListElement": [
           {"@type": "ListItem","position": 1,"name": "Beranda","item": "https://sentralemas.com/"},
-          {"@type": "ListItem","position": 2,"name": "Panduan Berlian","item": "https://sentralemas.com/berlian/"}
+          {"@type": "ListItem","position": 2,"name": "Blog","item": "https://sentralemas.com/blog/"},
+          {"@type": "ListItem","position": 3,"name": "Panduan Berlian","item": "https://sentralemas.com/blog/panduan-buyback-berlian/"}
         ]
       }
     </script>

--- a/blog/panduan-menilai-keaslian-emas-sebelum-cod/index.html
+++ b/blog/panduan-menilai-keaslian-emas-sebelum-cod/index.html
@@ -71,7 +71,7 @@
         <a itemprop="url" href="/#fitur"><span itemprop="name">Fitur</span></a>
         <a itemprop="url" href="/#diterima"><span itemprop="name">Yang Diterima</span></a>
         <a itemprop="url" href="/#harga"><span itemprop="name">Harga Buyback</span></a>
-        <a itemprop="url" href="/berlian/"><span itemprop="name">Panduan Berlian</span></a>
+        <a itemprop="url" href="/blog/panduan-buyback-berlian/"><span itemprop="name">Panduan Berlian</span></a>
         <a itemprop="url" href="/blog/"><span itemprop="name">Blog</span></a>
         <a itemprop="url" href="/#kontak"><span itemprop="name">Kontak</span></a>
       </nav>

--- a/harga/index.html
+++ b/harga/index.html
@@ -70,7 +70,7 @@
           <a itemprop="url" href="/#fitur"><span itemprop="name">Fitur</span></a>
           <a itemprop="url" href="/#diterima"><span itemprop="name">Yang Diterima</span></a>
           <a itemprop="url" href="#harga"><span itemprop="name">Harga Buyback</span></a>
-          <a itemprop="url" href="/berlian/"><span itemprop="name">Panduan Berlian</span></a>
+          <a itemprop="url" href="/blog/panduan-buyback-berlian/"><span itemprop="name">Panduan Berlian</span></a>
           <a itemprop="url" href="/blog/"><span itemprop="name">Blog</span></a>
           <a itemprop="url" href="/#kontak"><span itemprop="name">Kontak</span></a>
         </nav>
@@ -87,7 +87,7 @@
             <div class="btn-row mt-12">
               <a class="btn btn-gold" href="https://wa.me/6285591088503" target="_blank" rel="noopener noreferrer" data-track="wa-harga-page">WhatsApp untuk Update</a>
               <a class="btn btn-ghost" href="#harga">Lihat Tabel</a>
-              <a class="btn btn-ghost" href="/berlian/">Referensi Berlian</a>
+              <a class="btn btn-ghost" href="/blog/panduan-buyback-berlian/">Referensi Berlian</a>
             </div>
           </div>
           <div>
@@ -164,7 +164,7 @@
               <h2 id="diamondRedirectTitle" class="h2">Kami siapkan halaman khusus untuk panduan berlian.</h2>
               <p class="t-text">Pelajari kualitas 4C, kenali perbedaan tiap bentuk populer, serta dapatkan ringkasan sertifikat dan insight nilai buyback berlian.</p>
               <div class="btn-row mt-10">
-                <a class="btn btn-gold" href="/berlian/">Buka Panduan Berlian</a>
+                <a class="btn btn-gold" href="/blog/panduan-buyback-berlian/">Buka Panduan Berlian</a>
                 <a class="btn btn-ghost" href="https://wa.me/6285591088503" target="_blank" rel="noopener noreferrer" data-track="wa-panduan-berlian">Diskusi via WhatsApp</a>
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -99,7 +99,6 @@
           <a itemprop="url" href="#fitur"><span itemprop="name">Fitur</span></a>
           <a itemprop="url" href="#diterima"><span itemprop="name">Yang Diterima</span></a>
           <a itemprop="url" href="#harga"><span itemprop="name">Harga Buyback</span></a>
-          <a itemprop="url" href="/blog/panduan-buyback-berlian/"><span itemprop="name">Panduan Berlian</span></a>
           <a itemprop="url" href="/blog/"><span itemprop="name">Blog</span></a>
           <a itemprop="url" href="#kontak"><span itemprop="name">Kontak</span></a>
         </nav>

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
           <a itemprop="url" href="#fitur"><span itemprop="name">Fitur</span></a>
           <a itemprop="url" href="#diterima"><span itemprop="name">Yang Diterima</span></a>
           <a itemprop="url" href="#harga"><span itemprop="name">Harga Buyback</span></a>
-          <a itemprop="url" href="/berlian/"><span itemprop="name">Panduan Berlian</span></a>
+          <a itemprop="url" href="/blog/panduan-buyback-berlian/"><span itemprop="name">Panduan Berlian</span></a>
           <a itemprop="url" href="/blog/"><span itemprop="name">Blog</span></a>
           <a itemprop="url" href="#kontak"><span itemprop="name">Kontak</span></a>
         </nav>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -14,7 +14,7 @@
     <lastmod>2025-09-17T07:01:08+00:00</lastmod>
   </url>
   <url>
-    <loc>https://sentralemas.com/berlian/</loc>
+    <loc>https://sentralemas.com/blog/panduan-buyback-berlian/</loc>
     <priority>0.88</priority>
     <changefreq>daily</changefreq>
     <lastmod>2025-09-17T07:01:08+00:00</lastmod>


### PR DESCRIPTION
## Summary
- move the dedicated diamond guide into `blog/panduan-buyback-berlian/` and update canonical, breadcrumb, and navigation for the new path
- refresh blog listings and structured data so the diamond guide appears alongside other articles
- update site navigation, CTAs, and sitemap entries that previously linked to `/berlian/`

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d007985e408330931e3df8e355fecd