### PR TITLE
Add on-site search experience

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -127,6 +127,18 @@ nav a{ font-size:1.06rem; padding:.8rem .6rem }
 .menu{display:flex;gap:1rem}
 .hamb{display:none}
 .header-actions{display:flex;align-items:center;gap:1rem}
+.site-search{display:flex;align-items:center;gap:.35rem;padding:.2rem .3rem;border-radius:999px;border:1px solid rgba(255,255,255,.28);background:rgba(255,255,255,.12);color:#fff;min-height:38px;transition:border-color .2s ease,box-shadow .2s ease,background .2s ease}
+.site-search:focus-within{border-color:rgba(255,255,255,.45);box-shadow:0 0 0 3px rgba(212,175,55,.28)}
+.site-search__field{display:flex;align-items:center;gap:.3rem;width:100%}
+.site-search__input{flex:1 1 auto;min-width:0;background:transparent;border:0;color:inherit;font-size:.95rem;padding:.35rem .2rem}
+.site-search__input::placeholder{color:rgba(255,255,255,.75)}
+.site-search__input:focus{outline:none}
+.site-search__submit{border:0;background:transparent;color:inherit;width:2.35rem;height:2.35rem;border-radius:999px;display:grid;place-items:center;cursor:pointer;transition:background .2s ease,color .2s ease}
+.site-search__submit:hover{background:rgba(255,255,255,.18)}
+.site-search__submit:focus-visible{outline:3px solid var(--focus-ring);outline-offset:2px}
+.site-search--wide{max-width:640px;width:100%}
+.header-actions .site-search{max-width:240px}
+.header-actions .site-search__input{width:100%}
 #darkModeToggle .sun-icon,
 #darkModeToggle .moon-icon,
 #darkModeToggle .auto-icon {
@@ -177,6 +189,40 @@ nav a{ font-size:1.06rem; padding:.8rem .6rem }
 .feature, .t-card{transform-style:preserve-3d}
 @media (hover:hover) and (pointer:fine){ .feature, .t-card{transition: transform .15s ease; will-change: transform} }
 @media (max-width:860px){.menu{display:none}.hamb{display:inline-flex}.header-actions{gap:.8rem}}
+@media (max-width:720px){.header-actions{flex-wrap:wrap;justify-content:flex-end}.header-actions .site-search{flex:1 1 100%;max-width:none;order:2}}
+/* ---------- search results ---------- */
+.search-section{padding:4rem 0 3rem;background:var(--bg-primary)}
+.search-section .container{display:flex;flex-direction:column;gap:1.4rem}
+.search-header{display:flex;flex-direction:column;gap:.5rem;color:var(--text-primary)}
+.search-summary{margin:0;color:var(--text-secondary);font-size:1rem}
+.search-suggestions{display:flex;flex-direction:column;gap:.6rem;color:var(--text-secondary)}
+.search-suggestions__label{font-weight:600;letter-spacing:.01em}
+.search-suggestions__chips{display:flex;flex-wrap:wrap;gap:.5rem}
+.search-suggestion{padding:.45rem .9rem;border-radius:999px;border:1px solid rgba(212,175,55,.4);background:rgba(212,175,55,.12);font-weight:600;font-size:.95rem;color:var(--accent-green);cursor:pointer;transition:background .2s ease,border-color .2s ease,color .2s ease}
+.search-suggestion:hover{background:rgba(212,175,55,.22);border-color:rgba(212,175,55,.6)}
+.search-reset{align-self:flex-start}
+.search-results{list-style:none;margin:0;padding:0;display:grid;gap:1.2rem}
+.search-result{padding:1.3rem 1.4rem}
+.search-result__link{text-decoration:none;color:inherit;display:flex;flex-direction:column;gap:.6rem}
+.search-result__meta{margin:0;font-size:.85rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-secondary);font-weight:600}
+.search-result__title{margin:0;font-size:1.4rem;font-family:"Playfair Display",serif;color:var(--deep)}
+.search-result__excerpt{margin:0;font-size:1.05rem;color:var(--text-secondary);line-height:1.6}
+.search-result mark{background:rgba(212,175,55,.3);color:var(--deep);padding:0 .1rem;border-radius:3px}
+.search-empty{display:flex;flex-direction:column;align-items:center;gap:1rem;padding:2rem 1.4rem;text-align:center}
+.search-empty .h3{margin:0}
+.search-empty p{margin:0;color:var(--text-secondary);max-width:40ch}
+.search-empty .btn{align-self:center}
+.search-section .site-search{background:var(--paper);border:1px solid var(--border);color:var(--text-primary);box-shadow:var(--shadow)}
+.search-section .site-search:focus-within{border-color:var(--gold);box-shadow:0 0 0 3px rgba(212,175,55,.3)}
+.search-section .site-search__input::placeholder{color:var(--text-secondary)}
+.search-section .site-search__submit{color:var(--accent-green)}
+.search-section .site-search__submit:hover{background:rgba(212,175,55,.16);color:var(--accent-green)}
+.search-section .site-search__submit:focus-visible{outline:3px solid var(--focus-ring-strong);outline-offset:2px}
+@media (max-width:860px){.search-section{padding:3.2rem 0 2.6rem}}
+@media (max-width:640px){.search-result{padding:1.1rem}.search-result__title{font-size:1.3rem}.search-suggestions__chips{gap:.4rem}.search-suggestion{font-size:.9rem;padding:.4rem .75rem}}
+body.search-active .scroll-progress{display:none}
+body.search-active main>:not(.search-section){display:none}
+
 /* ---------- hero ---------- */
 .bling{position:relative}
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,5 +1,138 @@
 // Extracted from inline scripts in index.html
 
+function normalizeSearchText(value){
+  if(!value && value !== 0) return '';
+  var text = String(value);
+  try {
+    if(text.normalize){
+      text = text.normalize('NFD');
+    }
+  } catch(e) {}
+  return text.replace(/[\u0300-\u036f]/g, '').toLowerCase();
+}
+
+const SEARCH_INDEX = (function(){
+  const entries = [
+    {
+      id: 'home',
+      url: '/',
+      title: 'Sentral Emas – Terima Jual Emas & Berlian COD',
+      description: 'Menerima jual emas, berlian, jam tangan mewah, batu mulia via buyback aman COD se‑Jabodetabek & sekitarnya, mengikuti harga pasar hari transaksi. Transparan, cepat, terpercaya.',
+      excerpt: 'Layanan buyback emas, berlian, jam tangan mewah, serta batu mulia dengan COD aman dan appraisal transparan.',
+      type: 'Halaman',
+      category: 'Layanan',
+      date: '2025-01-05',
+      readingTime: '',
+      keywords: ['jual emas', 'buyback emas', 'cod', 'berlian', 'jam tangan mewah', 'batu mulia'],
+      priority: 6,
+      content: 'Sentral Emas menyediakan konsultasi buyback emas, berlian, jam tangan mewah, dan batu mulia dengan penjemputan COD Jabodetabek, estimasi harga pasar, proses appraisal terbuka, serta layanan cepat dan aman melalui WhatsApp.'
+    },
+    {
+      id: 'harga',
+      url: '/harga/',
+      title: 'Harga Buyback Emas COD | Sentral Emas',
+      description: 'Cek harga buyback emas, logam mulia, dan perhiasan terkini. Dilengkapi kalkulator estimasi dan kontak WhatsApp untuk update real-time.',
+      excerpt: 'Update harga buyback emas & logam mulia lengkap dengan kalkulator estimasi COD Sentral Emas.',
+      type: 'Halaman',
+      category: 'Harga',
+      date: '2025-09-17',
+      readingTime: '',
+      keywords: ['harga emas hari ini', 'harga buyback', 'kalkulator emas', 'logam mulia'],
+      priority: 5,
+      content: 'Halaman harga buyback menghadirkan tabel perhiasan, logam mulia baru dan lama, highlight pergerakan harga harian, waktu update WIB, tombol WhatsApp, dan kalkulator berat serta kadar emas untuk simulasi COD.'
+    },
+    {
+      id: 'blog',
+      url: '/blog/',
+      title: 'Blog Sentral Emas – Tips Jual Beli Emas COD',
+      description: 'Artikel dan panduan Sentral Emas seputar tips jual beli emas & berlian via COD yang aman dan transparan.',
+      excerpt: 'Kumpulan artikel, panduan, dan insight jual beli emas, berlian, serta layanan COD Sentral Emas.',
+      type: 'Blog',
+      category: 'Blog',
+      date: '2025-09-17',
+      readingTime: '',
+      keywords: ['blog emas', 'tips jual emas', 'panduan berlian', 'keaslian emas'],
+      priority: 4,
+      content: 'Blog Sentral Emas menyajikan edukasi jual beli emas dan berlian, referensi keaslian, strategi transaksi COD aman, hingga insight perhiasan dan harga pasar.'
+    },
+    {
+      id: 'panduan-buyback-berlian',
+      url: '/blog/panduan-buyback-berlian/',
+      title: 'Panduan Buyback Berlian: Kenali 4C, Bentuk, & Sertifikat',
+      description: 'Pelajari 4C berlian, variasi bentuk populer, dan panduan sertifikat untuk buyback berlian COD di Sentral Emas.',
+      excerpt: 'Ringkasan kualitas berlian, skala warna komersial, bentuk favorit, dan tips menyiapkan sertifikat saat buyback.',
+      type: 'Blog',
+      category: 'Panduan',
+      date: '2025-09-17',
+      readingTime: '±10 menit',
+      keywords: ['berlian', '4c', 'sertifikat gia', 'buyback berlian', 'panduan berlian'],
+      priority: 7,
+      content: 'Artikel membahas empat pilar 4C (cut, color, clarity, carat), tabel warna D sampai K, bentuk round, princess, cushion, hingga tips sertifikat GIA, perawatan, dan persiapan konsultasi buyback berlian COD bersama Sentral Emas.'
+    },
+    {
+      id: 'panduan-keaslian-emas',
+      url: '/blog/panduan-menilai-keaslian-emas-sebelum-cod/',
+      title: 'Panduan Menilai Keaslian Emas Sebelum COD',
+      description: 'Cara sederhana memeriksa keaslian emas di rumah sebelum transaksi COD bersama Sentral Emas. Lengkap dengan tips dokumentasi dan kapan perlu ahli.',
+      excerpt: 'Langkah memeriksa stempel, warna, densitas, uji magnet, dan dokumentasi sebelum transaksi emas COD.',
+      type: 'Blog',
+      category: 'Panduan',
+      date: '2025-09-12',
+      readingTime: '±7 menit',
+      keywords: ['keaslian emas', 'uji emas', 'uji magnet', 'uji asam', 'sentral emas'],
+      priority: 6,
+      content: 'Panduan menilai emas asli mencakup pemeriksaan stempel, perubahan warna, uji magnet dan uji asam, cara menimbang berat, menyiapkan foto atau video sebelum buyback, serta kapan berkonsultasi dengan tim Sentral Emas.'
+    },
+    {
+      id: 'keuntungan-jual-emas-cod',
+      url: '/blog/keuntungan-jual-emas-cod/',
+      title: 'Keuntungan Jual Emas via COD yang Aman',
+      description: 'Pelajari keuntungan menggunakan layanan buyback emas COD Sentral Emas beserta tips menyiapkan transaksi agar proses aman dan transparan.',
+      excerpt: 'Keunggulan transaksi buyback emas COD, keamanan penjemputan, dan tips menyiapkan barang sebelum tim datang.',
+      type: 'Blog',
+      category: 'Panduan',
+      date: '2025-09-05',
+      readingTime: '±6 menit',
+      keywords: ['jual emas cod', 'buyback emas', 'keamanan cod', 'tips jual emas'],
+      priority: 5,
+      content: 'Artikel merangkum manfaat buyback COD seperti appraisal transparan, pembayaran instan, transaksi di lokasi pelanggan, serta saran menata perhiasan dan dokumen sebelum tim Sentral Emas tiba.'
+    }
+  ];
+
+  return entries.map(function(entry, index){
+    const keywordList = Array.isArray(entry.keywords) ? entry.keywords : String(entry.keywords || '').split(',');
+    const keywords = keywordList.map(function(k){ return String(k || '').trim(); }).filter(function(k){ return k.length; });
+    const normalizedTitle = normalizeSearchText(entry.title);
+    const normalizedDescription = normalizeSearchText(entry.description || '');
+    const normalizedContent = normalizeSearchText(entry.content || '');
+    const normalizedKeywords = normalizeSearchText(keywords.join(' '));
+    const normalized = [normalizedTitle, normalizedDescription, normalizedContent, normalizedKeywords].join(' ').trim();
+    return {
+      id: entry.id || ('search-' + index),
+      url: entry.url,
+      title: entry.title,
+      description: entry.description || '',
+      excerpt: entry.excerpt || entry.description || '',
+      type: entry.type || 'Halaman',
+      category: entry.category || entry.type || 'Halaman',
+      date: entry.date || '',
+      readingTime: entry.readingTime || '',
+      keywords: keywords,
+      priority: entry.priority || 0,
+      content: entry.content || '',
+      normalized: normalized,
+      normalizedTitle: normalizedTitle,
+      normalizedDescription: normalizedDescription,
+      normalizedContent: normalizedContent,
+      normalizedKeywords: normalizedKeywords
+    };
+  });
+})();
+
+if(typeof window !== 'undefined'){
+  window.SENTRAL_EMAS_SEARCH_INDEX = SEARCH_INDEX;
+}
+
 /* istanbul ignore next */
 (function(){
   // ---- Scroll progress + Parallax (class-based; minimize reflow) ----
@@ -2197,6 +2330,260 @@ function format(number){
   });
 })();
 
+/* istanbul ignore next */
+(function(){
+  var searchSection = document.getElementById('searchResults');
+  if(!searchSection) return;
+
+  var body = document.body || document.documentElement;
+  var resultsList = searchSection.querySelector('[data-search-results]');
+  var summary = searchSection.querySelector('[data-search-summary]');
+  var emptyState = searchSection.querySelector('[data-search-empty]');
+  var emptyQueryEl = searchSection.querySelector('[data-search-empty-query]');
+  var resetLink = searchSection.querySelector('[data-search-reset]');
+  var suggestionsWrap = searchSection.querySelector('[data-search-suggestions]');
+  var suggestionButtons = suggestionsWrap ? Array.prototype.slice.call(suggestionsWrap.querySelectorAll('[data-search-suggestion]')) : [];
+  var forms = Array.prototype.slice.call(document.querySelectorAll('[data-search-form]'));
+  var inputs = Array.prototype.slice.call(document.querySelectorAll('[data-search-input]'));
+
+  var hasSearchParam = false;
+  var rawQuery = '';
+
+  try {
+    var params = new URLSearchParams(window.location.search || '');
+    if(params.has('s')){
+      hasSearchParam = true;
+      rawQuery = params.get('s') || '';
+    }
+  } catch(e){
+    if(window.location.search && window.location.search.indexOf('s=') !== -1){
+      hasSearchParam = true;
+      rawQuery = window.location.search.split('s=')[1] || '';
+    }
+  }
+
+  rawQuery = (rawQuery || '').replace(/\+/g, ' ').trim();
+
+  inputs.forEach(function(input){
+    if(!input) return;
+    input.value = rawQuery;
+  });
+
+  if(!hasSearchParam){
+    searchSection.hidden = true;
+    if(resetLink){ resetLink.hidden = true; }
+    return;
+  }
+
+  searchSection.hidden = false;
+
+  if(rawQuery){
+    if(body && body.classList){ body.classList.add('search-active'); }
+    if(resetLink){ resetLink.hidden = false; }
+    renderResults(rawQuery);
+    updatePageTitle(rawQuery);
+    if(typeof searchSection.focus === 'function'){
+      try { searchSection.focus(); } catch(_){}
+    }
+  } else {
+    if(body && body.classList){ body.classList.remove('search-active'); }
+    if(resetLink){ resetLink.hidden = true; }
+    updateSummary('Masukkan kata kunci pencarian untuk melihat hasil.');
+    if(emptyState){ emptyState.hidden = true; }
+  }
+
+  forms.forEach(function(form){
+    if(!form) return;
+    form.addEventListener('submit', function(ev){
+      var input = form.querySelector('[data-search-input]');
+      if(!input) return;
+      var value = (input.value || '').trim();
+      if(!value){
+        ev.preventDefault();
+        updateSummary('Masukkan kata kunci pencarian untuk melihat hasil.');
+        if(emptyState){ emptyState.hidden = true; }
+        input.focus();
+      }
+    });
+  });
+
+  suggestionButtons.forEach(function(button){
+    button.addEventListener('click', function(){
+      var value = button.getAttribute('data-search-suggestion') || '';
+      if(!value) return;
+      inputs.forEach(function(input){ if(input){ input.value = value; } });
+      var primary = forms[0];
+      if(primary){
+        if(typeof primary.requestSubmit === 'function'){
+          primary.requestSubmit();
+        } else {
+          primary.submit();
+        }
+      } else {
+        var url = new URL(window.location.href);
+        url.search = '?s=' + encodeURIComponent(value);
+        window.location.assign(url.toString());
+      }
+    });
+  });
+
+  function updateSummary(text){
+    if(summary){ summary.textContent = text; }
+  }
+
+  function renderResults(query){
+    if(!resultsList) return;
+    var normalizedQuery = normalizeSearchText(query);
+    var tokens = normalizedQuery.split(/\s+/).filter(Boolean);
+    var highlightTokens = query.split(/\s+/).filter(Boolean);
+    var matches = [];
+
+    if(tokens.length){
+      SEARCH_INDEX.forEach(function(entry){
+        if(!entry || !entry.normalized) return;
+        var matchesAll = tokens.every(function(token){ return entry.normalized.indexOf(token) !== -1; });
+        if(!matchesAll) return;
+        var score = computeScore(entry, tokens, normalizedQuery);
+        matches.push({ entry: entry, score: score });
+      });
+    }
+
+    matches.sort(function(a, b){
+      if(b.score !== a.score) return b.score - a.score;
+      var priorityDiff = (b.entry.priority || 0) - (a.entry.priority || 0);
+      if(priorityDiff) return priorityDiff;
+      var dateA = a.entry.date ? Date.parse(a.entry.date) : 0;
+      var dateB = b.entry.date ? Date.parse(b.entry.date) : 0;
+      if(dateB !== dateA) return dateB - dateA;
+      return a.entry.title.localeCompare(b.entry.title, 'id');
+    });
+
+    resultsList.innerHTML = '';
+
+    if(!matches.length){
+      updateSummary('Tidak ada hasil untuk "' + query + '".');
+      if(emptyState){ emptyState.hidden = false; }
+      if(emptyQueryEl){ emptyQueryEl.textContent = query; }
+      return;
+    }
+
+    var frag = document.createDocumentFragment();
+    matches.forEach(function(match){
+      var entry = match.entry;
+      var item = document.createElement('li');
+      item.className = 'search-result card';
+
+      var link = document.createElement('a');
+      link.className = 'search-result__link';
+      link.href = entry.url;
+
+      var metaText = buildMeta(entry);
+      if(metaText){
+        var meta = document.createElement('p');
+        meta.className = 'search-result__meta';
+        meta.textContent = metaText;
+        link.appendChild(meta);
+      }
+
+      var title = document.createElement('h2');
+      title.className = 'search-result__title';
+      title.innerHTML = highlightText(entry.title, highlightTokens);
+      link.appendChild(title);
+
+      var excerptSource = entry.excerpt || entry.description || entry.content;
+      if(excerptSource){
+        var excerpt = document.createElement('p');
+        excerpt.className = 'search-result__excerpt';
+        excerpt.innerHTML = highlightText(excerptSource, highlightTokens);
+        link.appendChild(excerpt);
+      }
+
+      item.appendChild(link);
+      frag.appendChild(item);
+    });
+
+    resultsList.appendChild(frag);
+    updateSummary('Menampilkan ' + matches.length + ' hasil untuk "' + query + '".');
+    if(emptyState){ emptyState.hidden = true; }
+    if(emptyQueryEl){ emptyQueryEl.textContent = query; }
+  }
+
+  function computeScore(entry, tokens, fullQuery){
+    var score = entry.priority || 0;
+    tokens.forEach(function(token){
+      if(entry.normalizedTitle && entry.normalizedTitle.indexOf(token) !== -1) score += 10;
+      if(entry.normalizedKeywords && entry.normalizedKeywords.indexOf(token) !== -1) score += 6;
+      if(entry.normalizedDescription && entry.normalizedDescription.indexOf(token) !== -1) score += 4;
+      if(entry.normalizedContent && entry.normalizedContent.indexOf(token) !== -1) score += 2;
+    });
+    if(fullQuery && entry.normalizedTitle && entry.normalizedTitle.indexOf(fullQuery) !== -1){
+      score += 5;
+    }
+    return score;
+  }
+
+  function buildMeta(entry){
+    var parts = [];
+    if(entry.category) parts.push(entry.category);
+    if(entry.date){
+      var formatted = formatDate(entry.date);
+      if(formatted) parts.push(formatted);
+    }
+    if(entry.readingTime) parts.push(entry.readingTime);
+    return parts.join(' • ');
+  }
+
+  function highlightText(text, tokens){
+    if(!text) return '';
+    var safe = escapeHtml(text);
+    if(!tokens || !tokens.length) return safe;
+    var escapedTokens = tokens.map(function(token){
+      return token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }).filter(Boolean);
+    if(!escapedTokens.length) return safe;
+    var pattern = new RegExp('(' + escapedTokens.join('|') + ')', 'gi');
+    return safe.replace(pattern, '<mark>$1</mark>');
+  }
+
+  function escapeHtml(str){
+    return String(str).replace(/[&<>"']/g, function(ch){
+      switch(ch){
+        case '&': return '&amp;';
+        case '<': return '&lt;';
+        case '>': return '&gt;';
+        case '"': return '&quot;';
+        case "'": return '&#39;';
+        default: return ch;
+      }
+    });
+  }
+
+  function formatDate(value){
+    if(!value) return '';
+    var date = new Date(value);
+    if(isNaN(date.getTime())) return '';
+    if(typeof Intl !== 'undefined' && Intl.DateTimeFormat){
+      try {
+        return new Intl.DateTimeFormat('id-ID', { day: '2-digit', month: 'long', year: 'numeric' }).format(date);
+      } catch(e){}
+    }
+    var months = ['Januari','Februari','Maret','April','Mei','Juni','Juli','Agustus','September','Oktober','November','Desember'];
+    var month = months[date.getMonth()] || '';
+    var day = ('0' + date.getDate()).slice(-2);
+    return month ? day + ' ' + month + ' ' + date.getFullYear() : '';
+  }
+
+  function updatePageTitle(query){
+    if(!query) return;
+    try {
+      var base = document.title || '';
+      if(base.toLowerCase().indexOf('sentral emas') !== -1){
+        document.title = 'Cari "' + query + '" | Sentral Emas';
+      }
+    } catch(e){}
+  }
+})();
+
 // Service worker register
 // SW register + Update Toast
 /* istanbul ignore next */
@@ -2359,6 +2746,8 @@ if ('serviceWorker' in navigator) {
 /* istanbul ignore else */
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
+    SEARCH_INDEX,
+    normalizeSearchText,
     PRICE_ADJUST_IDR,
     PRICE_TIMEOUT_MS,
     saveLastBasePrice,

--- a/assets/js/main.test.js
+++ b/assets/js/main.test.js
@@ -45,6 +45,20 @@ describe('main.js behaviours', () => {
       <div class="gallery"><img class="gallery-img"></div>
       <div id="currentDateTime"></div>
       <div id="typer"></div>
+      <section id="searchResults" hidden>
+        <div data-search-summary></div>
+        <form data-search-form>
+          <input data-search-input name="s" />
+        </form>
+        <div data-search-suggestions>
+          <button type="button" data-search-suggestion="emas">emas</button>
+        </div>
+        <a data-search-reset></a>
+        <ul data-search-results></ul>
+        <div data-search-empty hidden>
+          <span data-search-empty-query></span>
+        </div>
+      </section>
       <table><tbody id="goldPriceTable"></tbody></table>
       <div id="lmBaruHighlight" class="price-highlight">
         <div class="price-highlight-head">
@@ -742,6 +756,26 @@ describe('main.js behaviours', () => {
     logSpy.mockRestore();
     window.gtag = jest.fn();
     window.dataLayer = { push: jest.fn() };
+  });
+
+  test('search renders results when query parameter is present', async () => {
+    const originalUrl = window.location.href;
+    const url = new URL(originalUrl);
+    url.search = '?s=berlian';
+    window.history.replaceState(null, '', url.toString());
+
+    await loadMain();
+
+    const section = document.getElementById('searchResults');
+    expect(section.hidden).toBe(false);
+    expect(document.body.classList.contains('search-active')).toBe(true);
+    const items = section.querySelectorAll('[data-search-results] li');
+    expect(items.length).toBeGreaterThan(0);
+    expect(items[0].textContent.toLowerCase()).toContain('berlian');
+    const summary = section.querySelector('[data-search-summary]').textContent;
+    expect(summary).toMatch(/Menampilkan/);
+
+    window.history.replaceState(null, '', originalUrl);
   });
 
   test('service worker registration shows toast when waiting worker exists', async () => {

--- a/index.html
+++ b/index.html
@@ -113,6 +113,18 @@
             </svg>
             <svg class="auto-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>
           </button>
+          <form class="site-search" role="search" action="/" method="get" data-search-form>
+            <label class="sr-only" for="headerSearchInput">Cari di Sentral Emas</label>
+            <div class="site-search__field">
+              <input id="headerSearchInput" class="site-search__input" type="search" name="s" placeholder="Cari..." autocomplete="off" data-search-input />
+              <button class="site-search__submit" type="submit" aria-label="Kirim pencarian">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <circle cx="11" cy="11" r="7"/>
+                  <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                </svg>
+              </button>
+            </div>
+          </form>
           <a class="btn btn-gold hamb" href="/blog/">Blog</a>
         </div>
       </div>
@@ -121,6 +133,43 @@
 
     <!-- ===================== MAIN ===================== -->
     <main id="main-content" tabindex="-1">
+      <section id="searchResults" class="search-section" hidden tabindex="-1">
+        <div class="container">
+          <header class="search-header">
+            <span class="chip search-chip">Pencarian</span>
+            <h1 class="h2">Hasil Pencarian</h1>
+            <p class="search-summary" data-search-summary role="status" aria-live="polite">Masukkan kata kunci untuk mulai mencari konten Sentral Emas.</p>
+          </header>
+          <form class="site-search site-search--wide" role="search" action="/" method="get" data-search-form>
+            <label class="sr-only" for="searchQuery">Kata kunci pencarian</label>
+            <div class="site-search__field">
+              <input id="searchQuery" class="site-search__input" type="search" name="s" placeholder="Cari artikel, layanan, atau kata kunci..." autocomplete="off" data-search-input />
+              <button class="site-search__submit" type="submit" aria-label="Kirim pencarian">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <circle cx="11" cy="11" r="7"/>
+                  <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                </svg>
+              </button>
+            </div>
+          </form>
+          <div class="search-suggestions" data-search-suggestions>
+            <span class="search-suggestions__label">Pencarian populer:</span>
+            <div class="search-suggestions__chips">
+              <button type="button" class="search-suggestion" data-search-suggestion="harga emas">Harga emas</button>
+              <button type="button" class="search-suggestion" data-search-suggestion="jual emas cod">Jual emas COD</button>
+              <button type="button" class="search-suggestion" data-search-suggestion="panduan berlian">Panduan berlian</button>
+              <button type="button" class="search-suggestion" data-search-suggestion="keaslian emas">Keaslian emas</button>
+            </div>
+          </div>
+          <a class="btn btn-ghost search-reset" href="/" data-search-reset hidden>Hapus pencarian</a>
+          <ul class="search-results" data-search-results></ul>
+          <div class="search-empty card" data-search-empty hidden>
+            <h2 class="h3">Belum ada hasil</h2>
+            <p>Kami tidak menemukan kecocokan untuk “<span data-search-empty-query></span>”. Coba gunakan kata kunci lain atau hubungi tim kami lewat WhatsApp.</p>
+            <a class="btn btn-gold" href="https://wa.me/6285591088503" target="_blank" rel="noopener noreferrer">Chat via WhatsApp</a>
+          </div>
+        </div>
+      </section>
       <!-- ===================== HERO ===================== -->
       <section class="hero" id="home">
         <div class="container wrap">


### PR DESCRIPTION
## Summary
- add a compact search form to the header and a dedicated results section to surface `?s=` queries
- implement a curated search index plus rendering logic in `main.js` to serve results with highlighting
- style the search interface and extend Jest coverage with a search rendering test

## Testing
- npm test *(fails: jest not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d37c31688330b0b949011b5ec4b8