### PR TITLE
Prevent background scroll on search results

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -218,6 +218,7 @@ nav a{ font-size:1.06rem; padding:.8rem .6rem }
 .site-search-backdrop{position:fixed;inset:0;background:rgba(1,33,30,.55);backdrop-filter:blur(2px);z-index:40;opacity:0;visibility:hidden;pointer-events:none;transition:opacity .2s ease,visibility .2s ease}
 .site-search-backdrop.is-visible{opacity:1;visibility:visible;pointer-events:auto}
 body.has-mobile-search{overflow:hidden}
+html.search-active,body.search-active{overflow:hidden}
 /* ---------- search results ---------- */
 .search-section {
     position: fixed;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2336,6 +2336,7 @@ function format(number){
   if(!searchSection) return;
 
   var body = document.body || document.documentElement;
+  var docEl = document.documentElement;
   var resultsList = searchSection.querySelector('[data-search-results]');
   var summary = searchSection.querySelector('[data-search-summary]');
   var emptyState = searchSection.querySelector('[data-search-empty]');
@@ -2359,6 +2360,16 @@ function format(number){
   var mobileBackdrop = null;
   var forms = Array.prototype.slice.call(document.querySelectorAll('[data-search-form]'));
   var inputs = Array.prototype.slice.call(document.querySelectorAll('[data-search-input]'));
+
+  function addSearchActiveClass(){
+    if(body && body.classList){ body.classList.add('search-active'); }
+    if(docEl && docEl.classList){ docEl.classList.add('search-active'); }
+  }
+
+  function removeSearchActiveClass(){
+    if(body && body.classList){ body.classList.remove('search-active'); }
+    if(docEl && docEl.classList){ docEl.classList.remove('search-active'); }
+  }
 
   if(headerToggle){
     headerToggle.addEventListener('click', function(){
@@ -2429,6 +2440,7 @@ function format(number){
 
   if(!hasSearchParam){
     searchSection.hidden = true;
+    removeSearchActiveClass();
     if(resetLink){ resetLink.hidden = true; }
     return;
   }
@@ -2436,7 +2448,7 @@ function format(number){
   searchSection.hidden = false;
 
   if(rawQuery){
-    if(body && body.classList){ body.classList.add('search-active'); }
+    addSearchActiveClass();
     if(resetLink){ resetLink.hidden = false; }
     renderResults(rawQuery);
     updatePageTitle(rawQuery);
@@ -2444,7 +2456,7 @@ function format(number){
       try { searchSection.focus(); } catch(_){}
     }
   } else {
-    if(body && body.classList){ body.classList.remove('search-active'); }
+    removeSearchActiveClass();
     if(resetLink){ resetLink.hidden = true; }
     updateSummary('Masukkan kata kunci pencarian untuk melihat hasil.');
     if(emptyState){ emptyState.hidden = true; }

--- a/assets/js/main.test.js
+++ b/assets/js/main.test.js
@@ -769,6 +769,7 @@ describe('main.js behaviours', () => {
     const section = document.getElementById('searchResults');
     expect(section.hidden).toBe(false);
     expect(document.body.classList.contains('search-active')).toBe(true);
+    expect(document.documentElement.classList.contains('search-active')).toBe(true);
     const items = section.querySelectorAll('[data-search-results] li');
     expect(items.length).toBeGreaterThan(0);
     expect(items[0].textContent.toLowerCase()).toContain('berlian');


### PR DESCRIPTION
## Summary
- lock scrolling on the page when the search results panel is active to stop the underlying home page from moving
- toggle the `search-active` class on both the body and root elements so the CSS lock applies consistently
- extend the Jest test to verify the root element also receives the `search-active` class

## Testing
- npm test *(fails: jest is not installed and cannot be fetched in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d13bd645f88330901d520c9c57f616