### PR TITLE
feat: unify navbar search and icon buttons

### DIFF
--- a/404.html
+++ b/404.html
@@ -68,7 +68,35 @@
           </svg>
           <svg class="auto-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>
         </button>
-        <a class="btn btn-gold hamb" href="/#kontak">Hubungi</a>
+        <div class="header-search" data-header-search>
+          <button class="btn btn-gold btn-icon site-search-toggle" type="button" aria-label="Buka pencarian" aria-expanded="false" aria-controls="headerSearchInput" data-search-toggle data-close-label="Tutup pencarian">
+            <svg class="site-search-toggle__icon site-search-toggle__icon--open" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="11" cy="11" r="7"/>
+              <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+            </svg>
+            <svg class="site-search-toggle__icon site-search-toggle__icon--close" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <line x1="6" y1="6" x2="18" y2="18"/>
+              <line x1="18" y1="6" x2="6" y2="18"/>
+            </svg>
+          </button>
+          <form class="site-search" role="search" action="/" method="get" data-search-form>
+            <label class="sr-only" for="headerSearchInput">Cari di Sentral Emas</label>
+            <div class="site-search__field">
+              <input id="headerSearchInput" class="site-search__input" type="search" name="s" placeholder="Cari..." autocomplete="off" data-search-input />
+              <button class="site-search__submit" type="submit" aria-label="Kirim pencarian">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <circle cx="11" cy="11" r="7"/>
+                  <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                </svg>
+              </button>
+            </div>
+          </form>
+        </div>
+        <a class="btn btn-gold btn-icon hamb" href="/#kontak" aria-label="Hubungi Sentral Emas">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M22 16.92V21a1 1 0 0 1-1.09 1 19.86 19.86 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.86 19.86 0 0 1 3 3.09 1 1 0 0 1 4 2h3a1 1 0 0 1 1 .75l1 3a1 1 0 0 1-.27 1L7.91 9.91a16 16 0 0 0 6.18 6.18l3.16-1.82a1 1 0 0 1 1 .05l2.5 1.5A1 1 0 0 1 22 16.92z"/>
+          </svg>
+        </a>
       </div>
     </div>
   </header>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2333,16 +2333,14 @@ function format(number){
 /* istanbul ignore next */
 (function(){
   var searchSection = document.getElementById('searchResults');
-  if(!searchSection) return;
-
   var body = document.body || document.documentElement;
   var docEl = document.documentElement;
-  var resultsList = searchSection.querySelector('[data-search-results]');
-  var summary = searchSection.querySelector('[data-search-summary]');
-  var emptyState = searchSection.querySelector('[data-search-empty]');
-  var emptyQueryEl = searchSection.querySelector('[data-search-empty-query]');
-  var resetLink = searchSection.querySelector('[data-search-reset]');
-  var suggestionsWrap = searchSection.querySelector('[data-search-suggestions]');
+  var resultsList = searchSection ? searchSection.querySelector('[data-search-results]') : null;
+  var summary = searchSection ? searchSection.querySelector('[data-search-summary]') : null;
+  var emptyState = searchSection ? searchSection.querySelector('[data-search-empty]') : null;
+  var emptyQueryEl = searchSection ? searchSection.querySelector('[data-search-empty-query]') : null;
+  var resetLink = searchSection ? searchSection.querySelector('[data-search-reset]') : null;
+  var suggestionsWrap = searchSection ? searchSection.querySelector('[data-search-suggestions]') : null;
   var suggestionButtons = suggestionsWrap ? Array.prototype.slice.call(suggestionsWrap.querySelectorAll('[data-search-suggestion]')) : [];
   var headerSearch = document.querySelector('[data-header-search]');
   var headerToggle = headerSearch ? headerSearch.querySelector('[data-search-toggle]') : null;
@@ -2439,27 +2437,26 @@ function format(number){
   });
 
   if(!hasSearchParam){
-    searchSection.hidden = true;
+    if(searchSection){ searchSection.hidden = true; }
     removeSearchActiveClass();
     if(resetLink){ resetLink.hidden = true; }
-    return;
-  }
-
-  searchSection.hidden = false;
-
-  if(rawQuery){
-    addSearchActiveClass();
-    if(resetLink){ resetLink.hidden = false; }
-    renderResults(rawQuery);
-    updatePageTitle(rawQuery);
-    if(typeof searchSection.focus === 'function'){
-      try { searchSection.focus(); } catch(_){}
-    }
   } else {
-    removeSearchActiveClass();
-    if(resetLink){ resetLink.hidden = true; }
-    updateSummary('Masukkan kata kunci pencarian untuk melihat hasil.');
-    if(emptyState){ emptyState.hidden = true; }
+    if(searchSection){ searchSection.hidden = false; }
+
+    if(rawQuery){
+      addSearchActiveClass();
+      if(resetLink){ resetLink.hidden = false; }
+      renderResults(rawQuery);
+      updatePageTitle(rawQuery);
+      if(searchSection && typeof searchSection.focus === 'function'){
+        try { searchSection.focus(); } catch(_){}
+      }
+    } else {
+      removeSearchActiveClass();
+      if(resetLink){ resetLink.hidden = true; }
+      updateSummary('Masukkan kata kunci pencarian untuk melihat hasil.');
+      if(emptyState){ emptyState.hidden = true; }
+    }
   }
 
   forms.forEach(function(form){

--- a/blog/index.html
+++ b/blog/index.html
@@ -101,7 +101,35 @@
           </svg>
           <svg class="auto-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>
         </button>
-        <a class="btn btn-gold hamb" href="/#kontak">Hubungi</a>
+        <div class="header-search" data-header-search>
+          <button class="btn btn-gold btn-icon site-search-toggle" type="button" aria-label="Buka pencarian" aria-expanded="false" aria-controls="headerSearchInput" data-search-toggle data-close-label="Tutup pencarian">
+            <svg class="site-search-toggle__icon site-search-toggle__icon--open" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="11" cy="11" r="7"/>
+              <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+            </svg>
+            <svg class="site-search-toggle__icon site-search-toggle__icon--close" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <line x1="6" y1="6" x2="18" y2="18"/>
+              <line x1="18" y1="6" x2="6" y2="18"/>
+            </svg>
+          </button>
+          <form class="site-search" role="search" action="/" method="get" data-search-form>
+            <label class="sr-only" for="headerSearchInput">Cari di Sentral Emas</label>
+            <div class="site-search__field">
+              <input id="headerSearchInput" class="site-search__input" type="search" name="s" placeholder="Cari..." autocomplete="off" data-search-input />
+              <button class="site-search__submit" type="submit" aria-label="Kirim pencarian">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <circle cx="11" cy="11" r="7"/>
+                  <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                </svg>
+              </button>
+            </div>
+          </form>
+        </div>
+        <a class="btn btn-gold btn-icon hamb" href="/#kontak" aria-label="Hubungi Sentral Emas">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M22 16.92V21a1 1 0 0 1-1.09 1 19.86 19.86 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.86 19.86 0 0 1 3 3.09 1 1 0 0 1 4 2h3a1 1 0 0 1 1 .75l1 3a1 1 0 0 1-.27 1L7.91 9.91a16 16 0 0 0 6.18 6.18l3.16-1.82a1 1 0 0 1 1 .05l2.5 1.5A1 1 0 0 1 22 16.92z"/>
+          </svg>
+        </a>
       </div>
     </div>
   </header>

--- a/blog/keuntungan-jual-emas-cod/index.html
+++ b/blog/keuntungan-jual-emas-cod/index.html
@@ -96,7 +96,35 @@
           </svg>
           <svg class="auto-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>
         </button>
-        <a class="btn btn-gold hamb" href="/#kontak">Hubungi</a>
+        <div class="header-search" data-header-search>
+          <button class="btn btn-gold btn-icon site-search-toggle" type="button" aria-label="Buka pencarian" aria-expanded="false" aria-controls="headerSearchInput" data-search-toggle data-close-label="Tutup pencarian">
+            <svg class="site-search-toggle__icon site-search-toggle__icon--open" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="11" cy="11" r="7"/>
+              <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+            </svg>
+            <svg class="site-search-toggle__icon site-search-toggle__icon--close" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <line x1="6" y1="6" x2="18" y2="18"/>
+              <line x1="18" y1="6" x2="6" y2="18"/>
+            </svg>
+          </button>
+          <form class="site-search" role="search" action="/" method="get" data-search-form>
+            <label class="sr-only" for="headerSearchInput">Cari di Sentral Emas</label>
+            <div class="site-search__field">
+              <input id="headerSearchInput" class="site-search__input" type="search" name="s" placeholder="Cari..." autocomplete="off" data-search-input />
+              <button class="site-search__submit" type="submit" aria-label="Kirim pencarian">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <circle cx="11" cy="11" r="7"/>
+                  <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                </svg>
+              </button>
+            </div>
+          </form>
+        </div>
+        <a class="btn btn-gold btn-icon hamb" href="/#kontak" aria-label="Hubungi Sentral Emas">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M22 16.92V21a1 1 0 0 1-1.09 1 19.86 19.86 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.86 19.86 0 0 1 3 3.09 1 1 0 0 1 4 2h3a1 1 0 0 1 1 .75l1 3a1 1 0 0 1-.27 1L7.91 9.91a16 16 0 0 0 6.18 6.18l3.16-1.82a1 1 0 0 1 1 .05l2.5 1.5A1 1 0 0 1 22 16.92z"/>
+          </svg>
+        </a>
       </div>
     </div>
   </header>

--- a/blog/panduan-buyback-berlian/index.html
+++ b/blog/panduan-buyback-berlian/index.html
@@ -84,7 +84,36 @@
             </svg>
             <svg class="auto-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>
           </button>
-          <a class="btn btn-gold hamb" href="https://wa.me/6285591088503" target="_blank" rel="noopener noreferrer">WhatsApp</a>
+          <div class="header-search" data-header-search>
+            <button class="btn btn-gold btn-icon site-search-toggle" type="button" aria-label="Buka pencarian" aria-expanded="false" aria-controls="headerSearchInput" data-search-toggle data-close-label="Tutup pencarian">
+              <svg class="site-search-toggle__icon site-search-toggle__icon--open" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="11" cy="11" r="7"/>
+                <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+              </svg>
+              <svg class="site-search-toggle__icon site-search-toggle__icon--close" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <line x1="6" y1="6" x2="18" y2="18"/>
+                <line x1="18" y1="6" x2="6" y2="18"/>
+              </svg>
+            </button>
+            <form class="site-search" role="search" action="/" method="get" data-search-form>
+              <label class="sr-only" for="headerSearchInput">Cari di Sentral Emas</label>
+              <div class="site-search__field">
+                <input id="headerSearchInput" class="site-search__input" type="search" name="s" placeholder="Cari..." autocomplete="off" data-search-input />
+                <button class="site-search__submit" type="submit" aria-label="Kirim pencarian">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <circle cx="11" cy="11" r="7"/>
+                    <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                  </svg>
+                </button>
+              </div>
+            </form>
+          </div>
+          <a class="btn btn-gold btn-icon hamb" href="https://wa.me/6285591088503" target="_blank" rel="noopener noreferrer" aria-label="Chat via WhatsApp">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <rect x="3" y="5" width="18" height="14" rx="2" ry="2"/>
+              <path d="M8 19v3l-3-3"/>
+            </svg>
+          </a>
         </div>
       </div>
     </header>

--- a/blog/panduan-menilai-keaslian-emas-sebelum-cod/index.html
+++ b/blog/panduan-menilai-keaslian-emas-sebelum-cod/index.html
@@ -86,7 +86,35 @@
           </svg>
           <svg class="auto-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>
         </button>
-        <a class="btn btn-gold hamb" href="/#kontak">Hubungi</a>
+        <div class="header-search" data-header-search>
+          <button class="btn btn-gold btn-icon site-search-toggle" type="button" aria-label="Buka pencarian" aria-expanded="false" aria-controls="headerSearchInput" data-search-toggle data-close-label="Tutup pencarian">
+            <svg class="site-search-toggle__icon site-search-toggle__icon--open" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="11" cy="11" r="7"/>
+              <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+            </svg>
+            <svg class="site-search-toggle__icon site-search-toggle__icon--close" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <line x1="6" y1="6" x2="18" y2="18"/>
+              <line x1="18" y1="6" x2="6" y2="18"/>
+            </svg>
+          </button>
+          <form class="site-search" role="search" action="/" method="get" data-search-form>
+            <label class="sr-only" for="headerSearchInput">Cari di Sentral Emas</label>
+            <div class="site-search__field">
+              <input id="headerSearchInput" class="site-search__input" type="search" name="s" placeholder="Cari..." autocomplete="off" data-search-input />
+              <button class="site-search__submit" type="submit" aria-label="Kirim pencarian">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <circle cx="11" cy="11" r="7"/>
+                  <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                </svg>
+              </button>
+            </div>
+          </form>
+        </div>
+        <a class="btn btn-gold btn-icon hamb" href="/#kontak" aria-label="Hubungi Sentral Emas">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M22 16.92V21a1 1 0 0 1-1.09 1 19.86 19.86 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.86 19.86 0 0 1 3 3.09 1 1 0 0 1 4 2h3a1 1 0 0 1 1 .75l1 3a1 1 0 0 1-.27 1L7.91 9.91a16 16 0 0 0 6.18 6.18l3.16-1.82a1 1 0 0 1 1 .05l2.5 1.5A1 1 0 0 1 22 16.92z"/>
+          </svg>
+        </a>
       </div>
     </div>
   </header>

--- a/harga/index.html
+++ b/harga/index.html
@@ -85,7 +85,36 @@
             </svg>
             <svg class="auto-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>
           </button>
-          <a class="btn btn-gold hamb" href="https://wa.me/6285591088503" target="_blank" rel="noopener noreferrer">WhatsApp</a>
+          <div class="header-search" data-header-search>
+            <button class="btn btn-gold btn-icon site-search-toggle" type="button" aria-label="Buka pencarian" aria-expanded="false" aria-controls="headerSearchInput" data-search-toggle data-close-label="Tutup pencarian">
+              <svg class="site-search-toggle__icon site-search-toggle__icon--open" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="11" cy="11" r="7"/>
+                <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+              </svg>
+              <svg class="site-search-toggle__icon site-search-toggle__icon--close" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <line x1="6" y1="6" x2="18" y2="18"/>
+                <line x1="18" y1="6" x2="6" y2="18"/>
+              </svg>
+            </button>
+            <form class="site-search" role="search" action="/" method="get" data-search-form>
+              <label class="sr-only" for="headerSearchInput">Cari di Sentral Emas</label>
+              <div class="site-search__field">
+                <input id="headerSearchInput" class="site-search__input" type="search" name="s" placeholder="Cari..." autocomplete="off" data-search-input />
+                <button class="site-search__submit" type="submit" aria-label="Kirim pencarian">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <circle cx="11" cy="11" r="7"/>
+                    <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                  </svg>
+                </button>
+              </div>
+            </form>
+          </div>
+          <a class="btn btn-gold btn-icon hamb" href="https://wa.me/6285591088503" target="_blank" rel="noopener noreferrer" aria-label="Chat via WhatsApp">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <rect x="3" y="5" width="18" height="14" rx="2" ry="2"/>
+              <path d="M8 19v3l-3-3"/>
+            </svg>
+          </a>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- add the header search toggle and form to every static page so the navbar offers search everywhere
- replace text contact/WhatsApp CTAs in the navbar with SVG icon buttons to match existing dark-mode/search buttons
- relax the header search script so it still initializes when the global search section is absent

## Testing
- npm test -- --runInBand *(hangs locally; command aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d141051f4c833092b74424f9c9f932