### PR TITLE
Improve diamond highlight contrast in dark mode

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1062,10 +1062,24 @@ p, li, a { overflow-wrap: anywhere; word-break: break-word; }
 [data-theme="dark"] .diamond-scale-table thead th{ background:rgba(212,175,55,.14); color:var(--text-primary); }
 [data-theme="dark"] .diamond-scale-table tbody tr + tr th,
 [data-theme="dark"] .diamond-scale-table tbody tr + tr td{ border-top-color:rgba(212,175,55,.22); }
-[data-theme="dark"] .diamond-scale-table tbody tr[data-highlight="true"]{ background:rgba(212,175,55,.26); }
+[data-theme="dark"] .diamond-scale-table tbody tr[data-highlight="true"]{
+  background:linear-gradient(135deg,rgba(212,175,55,.3),rgba(212,175,55,.16));
+  box-shadow:inset 0 0 0 1px rgba(212,175,55,.32);
+}
 [data-theme="dark"] .diamond-scale-table tbody tr[data-highlight="true"] th[scope="row"],
-[data-theme="dark"] .diamond-scale-table tbody tr[data-highlight="true"] td{ color:#013D39; }
-[data-theme="dark"] .diamond-scale-flag{ background:rgba(212,175,55,.38); color:#013D39; }
+[data-theme="dark"] .diamond-scale-table tbody tr[data-highlight="true"] td{
+  color:var(--text-primary);
+  border-top-color:rgba(212,175,55,.32);
+}
+[data-theme="dark"] .diamond-scale-table tbody tr:first-child[data-highlight="true"] th[scope="row"],
+[data-theme="dark"] .diamond-scale-table tbody tr:first-child[data-highlight="true"] td{
+  border-top-color:transparent;
+}
+[data-theme="dark"] .diamond-scale-flag{
+  background:rgba(212,175,55,.32);
+  color:var(--ink);
+  box-shadow:0 0 0 1px rgba(212,175,55,.3);
+}
 
 .diamond-shape-grid{ display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:1.2rem; margin-top:1.8rem; }
 .diamond-shape-card{ background:var(--paper); border:1px solid var(--border); border-radius:18px; padding:1.4rem 1.5rem; box-shadow:0 12px 26px rgba(1,36,37,.08); display:flex; flex-direction:column; gap:.8rem; }


### PR DESCRIPTION
## Summary
- refresh the highlighted rows in the dark-theme diamond tables with a golden gradient frame so the emphasis looks intentional
- switch highlighted row text and badge colors to the light palette so copy remains legible against the richer accent background

## Testing
- npm test *(hangs on Jest run, aborted manually)*

------
https://chatgpt.com/codex/tasks/task_e_68d1f8c188b88330903f62af9621085e