### PR TITLE
Add hidden visitor counters

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
         script-src 'self' https://pluang.com https://www.googletagmanager.com https://www.google-analytics.com https://www.google.com https://www.gstatic.com https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net 'sha256-OmpoefMaacLy61S+i7zIyHiferp/ad+4RJSwODcABw4=' 'sha256-y4xXnjmvzpy7oQMw2l4evnsFZevxqtfXecoDCR5CnVU=' 'sha256-W/3/q7VezXXwzZMQxP8QPF6HgSLxhIFVUqnbB6YTmQQ=' 'sha256-DGXoYNDjkpgiN7XSylxGI8Q/NLgDFVTzhCc4+FSBho4=' 'sha256-U+66+q/PLjnT5dp8UVRgUZxG9z6xxCBCl4cdymRvn4Q=' 'sha256-RIF8DAiASgL99gqe+w6X4SLTZFCzkuWnjm2By3u8vv0=' 'sha256-dPg4cXBd21M3BQJX3JytBnvqfwe1ar/fCpDaI7DPhI4=' 'sha256-s5jGOr5xL+rh2kSZySAK1A+3R3HwIk5JY8B959Prq2k=';
         style-src 'self' 'unsafe-inline';
         font-src 'self';
-        connect-src 'self' https://pluang.com https://wa.me https://www.google-analytics.com https://www.googletagmanager.com https://www.google.com https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net;
+        connect-src 'self' https://pluang.com https://wa.me https://www.google-analytics.com https://www.googletagmanager.com https://www.google.com https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net https://api.countapi.xyz;
         frame-src 'self' https://www.googletagmanager.com https://www.google.com;
         form-action 'self';"
     />


### PR DESCRIPTION
## Summary
- add a hidden visitor metrics tracker that records total and active visitors through CountAPI while exposing the numbers only via a non-enumerable global helper
- update the CSP connect-src list to allow the counter service and expose helpers for tests
- expand the Jest suite with coverage for the secret visitor metrics logic

## Testing
- npx jest assets/js/main.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d2807757c88330b3a681451aa5ecb0