### PR TITLE
Fix CSP inline script violation

### DIFF
--- a/assets/js/web-vitals.js
+++ b/assets/js/web-vitals.js
@@ -1,0 +1,18 @@
+import {onCLS, onFID, onLCP} from 'https://unpkg.com/web-vitals@3/dist/web-vitals.attribution.js?module';
+
+const dataLayer = window.dataLayer || (window.dataLayer = []);
+
+function sendToDataLayer({name, delta, id, attribution}) {
+  dataLayer.push({
+    event: 'web-vitals',
+    event_category: 'Web Vitals',
+    event_action: name,
+    event_value: Math.round(name === 'CLS' ? delta * 1000 : delta),
+    event_label: id,
+    ...attribution,
+  });
+}
+
+onCLS(sendToDataLayer);
+onFID(sendToDataLayer);
+onLCP(sendToDataLayer);

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       content="default-src 'self';
         img-src 'self' data: https://www.google-analytics.com https://www.googletagmanager.com https://www.google.com https://www.google.co.id https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net;
         media-src 'self';
-        script-src 'self' https://pluang.com https://www.googletagmanager.com https://www.google-analytics.com https://www.google.com https://www.gstatic.com https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net 'sha256-OmpoefMaacLy61S+i7zIyHiferp/ad+4RJSwODcABw4=' 'sha256-y4xXnjmvzpy7oQMw2l4evnsFZevxqtfXecoDCR5CnVU=' 'sha256-W/3/q7VezXXwzZMQxP8QPF6HgSLxhIFVUqnbB6YTmQQ=' 'sha256-DGXoYNDjkpgiN7XSylxGI8Q/NLgDFVTzhCc4+FSBho4=' 'sha256-U+66+q/PLjnT5dp8UVRgUZxG9z6xxCBCl4cdymRvn4Q=' 'sha256-RIF8DAiASgL99gqe+w6X4SLTZFCzkuWnjm2By3u8vv0=' 'sha256-dPg4cXBd21M3BQJX3JytBnvqfwe1ar/fCpDaI7DPhI4=' 'sha256-s5jGOr5xL+rh2kSZySAK1A+3R3HwIk5JY8B959Prq2k=';
+        script-src 'self' https://pluang.com https://www.googletagmanager.com https://www.google-analytics.com https://www.google.com https://www.gstatic.com https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net https://unpkg.com 'sha256-OmpoefMaacLy61S+i7zIyHiferp/ad+4RJSwODcABw4=' 'sha256-y4xXnjmvzpy7oQMw2l4evnsFZevxqtfXecoDCR5CnVU=' 'sha256-W/3/q7VezXXwzZMQxP8QPF6HgSLxhIFVUqnbB6YTmQQ=' 'sha256-DGXoYNDjkpgiN7XSylxGI8Q/NLgDFVTzhCc4+FSBho4=' 'sha256-U+66+q/PLjnT5dp8UVRgUZxG9z6xxCBCl4cdymRvn4Q=' 'sha256-RIF8DAiASgL99gqe+w6X4SLTZFCzkuWnjm2By3u8vv0=' 'sha256-dPg4cXBd21M3BQJX3JytBnvqfwe1ar/fCpDaI7DPhI4=' 'sha256-s5jGOr5xL+rh2kSZySAK1A+3R3HwIk5JY8B959Prq2k=';
         style-src 'self' 'unsafe-inline';
         font-src 'self';
         connect-src 'self' https://pluang.com https://wa.me https://www.google-analytics.com https://www.googletagmanager.com https://www.google.com https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net;
@@ -1077,23 +1077,6 @@
       }
     </script>
     <script src="assets/js/main.js" defer></script>
-    <script type="module">
-      import {onCLS, onFID, onLCP} from 'https://unpkg.com/web-vitals@3/dist/web-vitals.attribution.js?module';
-
-      function sendToDataLayer({name, delta, id, attribution}) {
-        dataLayer.push({
-          event: 'web-vitals',
-          event_category: 'Web Vitals',
-          event_action: name,
-          event_value: Math.round(name === 'CLS' ? delta * 1000 : delta),
-          event_label: id,
-          ...attribution,
-        });
-      }
-
-      onCLS(sendToDataLayer);
-      onFID(sendToDataLayer);
-      onLCP(sendToDataLayer);
-    </script>
+    <script type="module" src="assets/js/web-vitals.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- move the web vitals reporting module out of the inline script so it complies with the CSP
- allow the site to load the CDN-hosted web vitals module by adding unpkg to the script-src list

## Testing
- `npm test` *(fails: hangs for several minutes and was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d2d51cb2088330b28cbe8e3537ece6