### PR TITLE
Improve preconnect hints for live price fetch

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1726,7 +1726,12 @@ function displayDateTimeWIB() {
 }
 displayDateTimeWIB();
 setInterval(displayDateTimeWIB, 60000);
-fetchGoldPrice();
+function shouldFetchGoldPrice(){
+  return !!(document.getElementById('goldPriceTable') || document.getElementById('lmBaruCurrent'));
+}
+if(shouldFetchGoldPrice()){
+  fetchGoldPrice();
+}
 
 window.addEventListener('resize', function(){
   if(!LM_BARU_SPARKLINE_META || !LM_BARU_SPARKLINE_META.hasSeries) return;

--- a/harga/index.html
+++ b/harga/index.html
@@ -54,6 +54,12 @@
     <link rel="preload" href="/assets/css/fonts.css" as="style">
     <link rel="stylesheet" href="/assets/css/fonts.css">
     <link rel="stylesheet" href="/assets/css/styles.css">
+    <link rel="dns-prefetch" href="https://pluang.com">
+    <link rel="preconnect" href="https://pluang.com" crossorigin>
+    <link rel="dns-prefetch" href="https://wa.me">
+    <link rel="preconnect" href="https://wa.me" crossorigin>
+    <link rel="dns-prefetch" href="https://www.googletagmanager.com">
+    <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
     <link rel="icon" href="/assets/icons/favicon.ico" sizes="32x32" type="image/x-icon"/>
     <link rel="shortcut icon" href="/assets/icons/favicon.ico" type="image/x-icon"/>
     <link rel="icon" href="/assets/icons/logo-48x48.png" type="image/png"/>

--- a/index.html
+++ b/index.html
@@ -55,11 +55,11 @@
     <link rel="stylesheet" href="assets/css/fonts.css">
     <link rel="stylesheet" href="assets/css/styles.css">
     <link rel="dns-prefetch" href="https://pluang.com">
-    <link rel="preconnect" href="https://pluang.com">
+    <link rel="preconnect" href="https://pluang.com" crossorigin>
     <link rel="dns-prefetch" href="https://wa.me">
-    <link rel="preconnect" href="https://wa.me">
+    <link rel="preconnect" href="https://wa.me" crossorigin>
     <link rel="dns-prefetch" href="https://www.googletagmanager.com">
-    <link rel="preconnect" href="https://www.googletagmanager.com">
+    <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
     <!-- PWA: manifest & app capability -->
     <link rel="manifest" href="./manifest.webmanifest">
 


### PR DESCRIPTION
## Summary
- add crossorigin-aware preconnect hints for Pluang, wa.me, and Google Tag Manager on the home and harga pages
- prevent the live price fetch from running on pages that do not render the price widgets to avoid needless network work

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68d2e01fd108833087645a257d304785