### PR TITLE
Improve preconnect hints and defer web vitals loading

### DIFF
--- a/404.html
+++ b/404.html
@@ -150,6 +150,5 @@
 
   
   <script src="/assets/js/main.js" defer></script>
-  <script type="module" src="/assets/js/web-vitals.js"></script>
 </body>
 </html>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1726,7 +1726,12 @@ function displayDateTimeWIB() {
 }
 displayDateTimeWIB();
 setInterval(displayDateTimeWIB, 60000);
-fetchGoldPrice();
+function shouldFetchGoldPrice(){
+  return !!(document.getElementById('goldPriceTable') || document.getElementById('lmBaruCurrent'));
+}
+if(shouldFetchGoldPrice()){
+  fetchGoldPrice();
+}
 
 window.addEventListener('resize', function(){
   if(!LM_BARU_SPARKLINE_META || !LM_BARU_SPARKLINE_META.hasSeries) return;
@@ -2881,7 +2886,7 @@ if ('serviceWorker' in navigator) {
 (function(){
   const THEME_KEY = 'sentral_emas_theme';
   const toggle = document.getElementById('darkModeToggle');
-  
+
   if (!toggle) return;
 
   function applyTheme(theme) {
@@ -2929,6 +2934,47 @@ if ('serviceWorker' in navigator) {
         applyTheme('auto');
       }
     });
+  }
+})();
+
+/* istanbul ignore next */
+(function(){
+  if (typeof window === 'undefined') return;
+
+  var hasScheduled = false;
+
+  function loadWebVitals(){
+    if (hasScheduled) return;
+    hasScheduled = true;
+
+    if (document.querySelector('script[data-web-vitals]')) return;
+
+    var script = document.createElement('script');
+    script.type = 'module';
+    script.src = '/assets/js/web-vitals.js';
+    script.setAttribute('data-web-vitals', 'true');
+
+    if ('fetchPriority' in script) {
+      script.fetchPriority = 'low';
+    } else {
+      script.setAttribute('fetchpriority', 'low');
+    }
+
+    document.head.appendChild(script);
+  }
+
+  function scheduleLoad(){
+    if ('requestIdleCallback' in window) {
+      requestIdleCallback(function(){ loadWebVitals(); });
+    } else {
+      setTimeout(loadWebVitals, 0);
+    }
+  }
+
+  if (document.readyState === 'complete') {
+    scheduleLoad();
+  } else {
+    window.addEventListener('load', scheduleLoad, { once: true });
   }
 })();
 

--- a/blog/checklist-foto-emas-cod/index.html
+++ b/blog/checklist-foto-emas-cod/index.html
@@ -190,6 +190,5 @@
     <div class="container copy">© <span id="yr"></span> Sentral Emas • Blog</div>
   </footer>
   <script src="/assets/js/main.js" defer></script>
-  <script type="module" src="/assets/js/web-vitals.js"></script>
 </body>
 </html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -223,6 +223,5 @@
     <div class="container copy">© <span id="yr"></span> Sentral Emas • Blog</div>
   </footer>
   <script src="/assets/js/main.js" defer></script>
-  <script type="module" src="/assets/js/web-vitals.js"></script>
 </body>
 </html>

--- a/blog/keuntungan-jual-emas-cod/index.html
+++ b/blog/keuntungan-jual-emas-cod/index.html
@@ -187,6 +187,5 @@
     <div class="container copy">© <span id="yr"></span> Sentral Emas • Blog</div>
   </footer>
   <script src="/assets/js/main.js" defer></script>
-  <script type="module" src="/assets/js/web-vitals.js"></script>
 </body>
 </html>

--- a/blog/panduan-buyback-berlian/index.html
+++ b/blog/panduan-buyback-berlian/index.html
@@ -612,6 +612,5 @@
     </script>
 
     <script src="/assets/js/main.js" defer></script>
-    <script type="module" src="/assets/js/web-vitals.js"></script>
   </body>
 </html>

--- a/blog/panduan-jual-emas-tanpa-surat/index.html
+++ b/blog/panduan-jual-emas-tanpa-surat/index.html
@@ -243,6 +243,5 @@
     <div class="container copy">© <span id="yr"></span> Sentral Emas • Blog</div>
   </footer>
   <script src="/assets/js/main.js" defer></script>
-  <script type="module" src="/assets/js/web-vitals.js"></script>
 </body>
 </html>

--- a/blog/panduan-menilai-keaslian-emas-sebelum-cod/index.html
+++ b/blog/panduan-menilai-keaslian-emas-sebelum-cod/index.html
@@ -182,6 +182,5 @@
     <div class="container copy">© <span id="yr"></span> Sentral Emas • Blog</div>
   </footer>
   <script src="/assets/js/main.js" defer></script>
-  <script type="module" src="/assets/js/web-vitals.js"></script>
 </body>
 </html>

--- a/harga/index.html
+++ b/harga/index.html
@@ -54,6 +54,12 @@
     <link rel="preload" href="/assets/css/fonts.css" as="style">
     <link rel="stylesheet" href="/assets/css/fonts.css">
     <link rel="stylesheet" href="/assets/css/styles.css">
+    <link rel="dns-prefetch" href="https://pluang.com">
+    <link rel="preconnect" href="https://pluang.com" crossorigin>
+    <link rel="dns-prefetch" href="https://wa.me">
+    <link rel="preconnect" href="https://wa.me" crossorigin>
+    <link rel="dns-prefetch" href="https://www.googletagmanager.com">
+    <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
     <link rel="icon" href="/assets/icons/favicon.ico" sizes="32x32" type="image/x-icon"/>
     <link rel="shortcut icon" href="/assets/icons/favicon.ico" type="image/x-icon"/>
     <link rel="icon" href="/assets/icons/logo-48x48.png" type="image/png"/>
@@ -427,6 +433,5 @@
       }
     </script>
     <script src="/assets/js/main.js" defer></script>
-    <script type="module" src="/assets/js/web-vitals.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -55,11 +55,11 @@
     <link rel="stylesheet" href="assets/css/fonts.css">
     <link rel="stylesheet" href="assets/css/styles.css">
     <link rel="dns-prefetch" href="https://pluang.com">
-    <link rel="preconnect" href="https://pluang.com">
+    <link rel="preconnect" href="https://pluang.com" crossorigin>
     <link rel="dns-prefetch" href="https://wa.me">
-    <link rel="preconnect" href="https://wa.me">
+    <link rel="preconnect" href="https://wa.me" crossorigin>
     <link rel="dns-prefetch" href="https://www.googletagmanager.com">
-    <link rel="preconnect" href="https://www.googletagmanager.com">
+    <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
     <!-- PWA: manifest & app capability -->
     <link rel="manifest" href="./manifest.webmanifest">
 
@@ -1102,6 +1102,5 @@
     })(window,document,'script','dataLayer','GTM-5D39RVL3');</script>
     <!-- End Google Tag Manager -->
     <script src="assets/js/main.js" defer></script>
-    <script type="module" src="assets/js/web-vitals.js"></script>
   </body>
 </html>

--- a/offline.html
+++ b/offline.html
@@ -103,6 +103,5 @@
     </div>
   </div>
   <script src="/assets/js/main.js" defer></script>
-  <script type="module" src="/assets/js/web-vitals.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add crossorigin-aware preconnect hints for Pluang, wa.me, and Google Tag Manager on the home and harga pages
- prevent the live price fetch from running on pages that do not render the price widgets to avoid needless network work
- lazy-load the web-vitals module after page load to remove it from the LCP critical request chain

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68d2e01fd108833087645a257d304785