### PR TITLE
Use semantic list markup for blog cards

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -304,7 +304,7 @@ footer .wa-badge{margin-top:1.6rem;align-items:flex-start;text-align:left}
 .wa-badge__identity{display:inline-flex;align-items:center;gap:.45rem;font-weight:700;font-size:1.05rem;letter-spacing:.01em;color:inherit}
 .wa-badge__verified{display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px}
 .wa-badge__verified img{display:block;width:100%;height:auto}
-.wa-badge__cta{margin-top:.2rem;display:inline-flex;align-items:center;justify-content:center;padding:.7rem 1.3rem !important;border-radius:999px;background:#128c7e;color:#fff;font-weight:600;text-decoration:none;border:0;transition:transform .2s ease,box-shadow .2s ease,filter .2s ease}
+.wa-badge__cta{margin-top:.2rem;display:inline-flex;align-items:center;justify-content:center;padding:.7rem 1.3rem !important;border-radius:999px;background:#075e54;color:#fff;font-weight:600;text-decoration:none;border:0;transition:transform .2s ease,box-shadow .2s ease,filter .2s ease}
 .wa-badge__cta:hover{filter:brightness(1.05);box-shadow:0 12px 28px rgba(37,211,102,.28);transform:translateY(-1px)}
 .wa-badge__cta:focus-visible{outline:3px solid rgba(37,211,102,.45);outline-offset:3px}
 .wa-badge__cta:active{transform:translateY(0)}
@@ -665,7 +665,8 @@ p, li, a { overflow-wrap: anywhere; word-break: break-word; }
 .blog-chip{ color:var(--text-primary); border:1px solid rgba(1,61,57,.16); font-size:.85rem; text-transform:uppercase; letter-spacing:.06em }
 .blog-title{ margin:0 }
 .blog-lead{ margin:0; color:var(--text-secondary); max-width:65ch }
-.blog-grid{ display:grid; gap:1.6rem; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); max-width:760px; margin:0 auto }
+.blog-grid{ display:grid; gap:1.6rem; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); max-width:760px; margin:0 auto; padding:0; list-style:none }
+.blog-grid>li{ list-style:none; margin:0; padding:0 }
 .home-blog-grid{ max-width:none; margin:1.6rem 0 0; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)) }
 .home-blog-grid .blog-card{ height:100% }
 .home-blog-grid .blog-card__link{ height:100% }

--- a/blog/index.html
+++ b/blog/index.html
@@ -160,63 +160,73 @@
       <h1 class="h2 blog-title">Blog Sentral Emas</h1>
       <p class="blog-lead">Kumpulan artikel, panduan, dan insight seputar jual beli emas, berlian, serta layanan COD aman oleh tim Sentral Emas.</p>
     </header>
-    <div class="blog-grid">
-        <article class="blog-card">
-          <a class="blog-card__link" href="/blog/panduan-jual-emas-tanpa-surat/">
-            <span class="blog-card__badge">Panduan</span>
-            <h2 class="blog-card__title">Panduan Jual Emas Tanpa Surat: Syarat, Risiko, dan Solusi Aman</h2>
-            <p class="blog-card__excerpt">Pelajari cara jual emas tanpa surat resmi beserta syarat minimum, mitigasi risiko, dan layanan COD aman dari Sentral Emas.</p>
-            <dl class="blog-card__meta">
-              <div><dt>Tanggal</dt><dd>3 Oktober 2025</dd></div>
-              <div><dt>Durasi baca</dt><dd>±9 menit</dd></div>
-            </dl>
-          </a>
-        </article>
-        <article class="blog-card">
-          <a class="blog-card__link" href="/blog/checklist-foto-emas-cod/">
-            <span class="blog-card__badge">Panduan</span>
-            <h2 class="blog-card__title">Checklist Foto &amp; Dokumen Emas Sebelum Konsultasi COD</h2>
-            <p class="blog-card__excerpt">Siapkan foto berkualitas dan dokumen pendukung agar estimasi buyback COD lebih cepat dan akurat.</p>
-            <dl class="blog-card__meta">
-              <div><dt>Tanggal</dt><dd>23 September 2025</dd></div>
-              <div><dt>Durasi baca</dt><dd>±8 menit</dd></div>
-            </dl>
-          </a>
-        </article>
-        <article class="blog-card">
-          <a class="blog-card__link" href="/blog/panduan-buyback-berlian/">
-            <span class="blog-card__badge">Panduan</span>
-            <h2 class="blog-card__title">Panduan Buyback Berlian: Pahami 4C &amp; Sertifikat</h2>
-            <p class="blog-card__excerpt">Pelajari kualitas berlian, bentuk populer, dan dokumen penting sebelum konsultasi buyback COD.</p>
-            <dl class="blog-card__meta">
-              <div><dt>Tanggal</dt><dd>17 September 2025</dd></div>
-              <div><dt>Durasi baca</dt><dd>±10 menit</dd></div>
-            </dl>
-          </a>
-        </article>
-        <article class="blog-card">
-          <a class="blog-card__link" href="/blog/panduan-menilai-keaslian-emas-sebelum-cod/">
-            <span class="blog-card__badge">Panduan</span>
-            <h2 class="blog-card__title">Panduan Menilai Keaslian Emas Sebelum COD</h2>
-            <p class="blog-card__excerpt">Langkah praktis memeriksa emas di rumah sebelum tim Sentral Emas datang, lengkap dengan tips dokumentasi.</p>
-            <dl class="blog-card__meta">
-              <div><dt>Tanggal</dt><dd>12 September 2025</dd></div>
-              <div><dt>Durasi baca</dt><dd>±7 menit</dd></div>
-            </dl>
-          </a>
-        </article>
-        <article class="blog-card">
-          <a class="blog-card__link" href="/blog/keuntungan-jual-emas-cod/">
-            <span class="blog-card__badge">Panduan</span>
-            <h2 class="blog-card__title">Keuntungan Jual Emas via COD yang Aman</h2>
-            <p class="blog-card__excerpt">Kenapa buyback emas COD bisa lebih praktis dan aman, plus tips menyiapkan barang sebelum tim datang.</p>
-            <dl class="blog-card__meta">
-              <div><dt>Tanggal</dt><dd>5 September 2025</dd></div>
-              <div><dt>Durasi baca</dt><dd>±6 menit</dd></div>
-            </dl>
-          </a>
-        </article>
-      </div>
+    <ul class="blog-grid">
+        <li>
+          <article class="blog-card">
+            <a class="blog-card__link" href="/blog/panduan-jual-emas-tanpa-surat/">
+              <span class="blog-card__badge">Panduan</span>
+              <h2 class="blog-card__title">Panduan Jual Emas Tanpa Surat: Syarat, Risiko, dan Solusi Aman</h2>
+              <p class="blog-card__excerpt">Pelajari cara jual emas tanpa surat resmi beserta syarat minimum, mitigasi risiko, dan layanan COD aman dari Sentral Emas.</p>
+              <dl class="blog-card__meta">
+                <div><dt>Tanggal</dt><dd>3 Oktober 2025</dd></div>
+                <div><dt>Durasi baca</dt><dd>±9 menit</dd></div>
+              </dl>
+            </a>
+          </article>
+        </li>
+        <li>
+          <article class="blog-card">
+            <a class="blog-card__link" href="/blog/checklist-foto-emas-cod/">
+              <span class="blog-card__badge">Panduan</span>
+              <h2 class="blog-card__title">Checklist Foto &amp; Dokumen Emas Sebelum Konsultasi COD</h2>
+              <p class="blog-card__excerpt">Siapkan foto berkualitas dan dokumen pendukung agar estimasi buyback COD lebih cepat dan akurat.</p>
+              <dl class="blog-card__meta">
+                <div><dt>Tanggal</dt><dd>23 September 2025</dd></div>
+                <div><dt>Durasi baca</dt><dd>±8 menit</dd></div>
+              </dl>
+            </a>
+          </article>
+        </li>
+        <li>
+          <article class="blog-card">
+            <a class="blog-card__link" href="/blog/panduan-buyback-berlian/">
+              <span class="blog-card__badge">Panduan</span>
+              <h2 class="blog-card__title">Panduan Buyback Berlian: Pahami 4C &amp; Sertifikat</h2>
+              <p class="blog-card__excerpt">Pelajari kualitas berlian, bentuk populer, dan dokumen penting sebelum konsultasi buyback COD.</p>
+              <dl class="blog-card__meta">
+                <div><dt>Tanggal</dt><dd>17 September 2025</dd></div>
+                <div><dt>Durasi baca</dt><dd>±10 menit</dd></div>
+              </dl>
+            </a>
+          </article>
+        </li>
+        <li>
+          <article class="blog-card">
+            <a class="blog-card__link" href="/blog/panduan-menilai-keaslian-emas-sebelum-cod/">
+              <span class="blog-card__badge">Panduan</span>
+              <h2 class="blog-card__title">Panduan Menilai Keaslian Emas Sebelum COD</h2>
+              <p class="blog-card__excerpt">Langkah praktis memeriksa emas di rumah sebelum tim Sentral Emas datang, lengkap dengan tips dokumentasi.</p>
+              <dl class="blog-card__meta">
+                <div><dt>Tanggal</dt><dd>12 September 2025</dd></div>
+                <div><dt>Durasi baca</dt><dd>±7 menit</dd></div>
+              </dl>
+            </a>
+          </article>
+        </li>
+        <li>
+          <article class="blog-card">
+            <a class="blog-card__link" href="/blog/keuntungan-jual-emas-cod/">
+              <span class="blog-card__badge">Panduan</span>
+              <h2 class="blog-card__title">Keuntungan Jual Emas via COD yang Aman</h2>
+              <p class="blog-card__excerpt">Kenapa buyback emas COD bisa lebih praktis dan aman, plus tips menyiapkan barang sebelum tim datang.</p>
+              <dl class="blog-card__meta">
+                <div><dt>Tanggal</dt><dd>5 September 2025</dd></div>
+                <div><dt>Durasi baca</dt><dd>±6 menit</dd></div>
+              </dl>
+            </a>
+          </article>
+        </li>
+      </ul>
     </div>
   </main>
   <footer class="blog-footer">

--- a/index.html
+++ b/index.html
@@ -549,41 +549,47 @@
           <div class="accent-title">Panduan &amp; Artikel</div>
           <h2 id="insightTitle" class="h2">Tips Jual Emas &amp; Berlian COD Terbaru</h2>
           <p class="text-muted mw-70ch">Ingin memahami cara <strong>jual emas COD Jabodetabek</strong> yang aman dan menguntungkan? Jelajahi pilihan artikel edukatif dari <a href="/blog/">Blog Sentral Emas</a> mengenai strategi jual emas tanpa surat, checklist dokumentasi, hingga panduan buyback berlian sehingga Anda siap sebelum janji temu.</p>
-          <div class="blog-grid home-blog-grid" role="list">
-            <article class="blog-card" role="listitem">
-              <a class="blog-card__link" href="/blog/panduan-jual-emas-tanpa-surat/">
-                <span class="blog-card__badge">Panduan</span>
-                <h3 class="blog-card__title">Panduan Jual Emas Tanpa Surat: Syarat, Risiko, dan Solusi Aman</h3>
-                <p class="blog-card__excerpt">Pelajari strategi aman menjual emas warisan atau tanpa nota, lengkap dengan dokumen pengganti dan tips verifikasi agar harga tetap maksimal.</p>
-                <dl class="blog-card__meta">
-                  <div><dt>Tanggal</dt><dd>3 Oktober 2025</dd></div>
-                  <div><dt>Durasi baca</dt><dd>±9 menit</dd></div>
-                </dl>
-              </a>
-            </article>
-            <article class="blog-card" role="listitem">
-              <a class="blog-card__link" href="/blog/checklist-foto-emas-cod/">
-                <span class="blog-card__badge">Panduan</span>
-                <h3 class="blog-card__title">Checklist Foto &amp; Dokumen Emas Sebelum Konsultasi COD</h3>
-                <p class="blog-card__excerpt">Siapkan foto detail, bukti pendukung, dan data berat sehingga tim Sentral Emas dapat memberi estimasi buyback lebih cepat sejak awal.</p>
-                <dl class="blog-card__meta">
-                  <div><dt>Tanggal</dt><dd>23 September 2025</dd></div>
-                  <div><dt>Durasi baca</dt><dd>±8 menit</dd></div>
-                </dl>
-              </a>
-            </article>
-            <article class="blog-card" role="listitem">
-              <a class="blog-card__link" href="/blog/panduan-buyback-berlian/">
-                <span class="blog-card__badge">Panduan</span>
-                <h3 class="blog-card__title">Panduan Buyback Berlian: Kenali 4C, Bentuk, &amp; Sertifikat</h3>
-                <p class="blog-card__excerpt">Ketahui standar penilaian berlian, kualitas 4C, serta dokumen yang perlu Anda siapkan ketika menjual berlian via COD.</p>
-                <dl class="blog-card__meta">
-                  <div><dt>Tanggal</dt><dd>17 September 2025</dd></div>
-                  <div><dt>Durasi baca</dt><dd>±10 menit</dd></div>
-                </dl>
-              </a>
-            </article>
-          </div>
+          <ul class="blog-grid home-blog-grid">
+            <li>
+              <article class="blog-card">
+                <a class="blog-card__link" href="/blog/panduan-jual-emas-tanpa-surat/">
+                  <span class="blog-card__badge">Panduan</span>
+                  <h3 class="blog-card__title">Panduan Jual Emas Tanpa Surat: Syarat, Risiko, dan Solusi Aman</h3>
+                  <p class="blog-card__excerpt">Pelajari strategi aman menjual emas warisan atau tanpa nota, lengkap dengan dokumen pengganti dan tips verifikasi agar harga tetap maksimal.</p>
+                  <dl class="blog-card__meta">
+                    <div><dt>Tanggal</dt><dd>3 Oktober 2025</dd></div>
+                    <div><dt>Durasi baca</dt><dd>±9 menit</dd></div>
+                  </dl>
+                </a>
+              </article>
+            </li>
+            <li>
+              <article class="blog-card">
+                <a class="blog-card__link" href="/blog/checklist-foto-emas-cod/">
+                  <span class="blog-card__badge">Panduan</span>
+                  <h3 class="blog-card__title">Checklist Foto &amp; Dokumen Emas Sebelum Konsultasi COD</h3>
+                  <p class="blog-card__excerpt">Siapkan foto detail, bukti pendukung, dan data berat sehingga tim Sentral Emas dapat memberi estimasi buyback lebih cepat sejak awal.</p>
+                  <dl class="blog-card__meta">
+                    <div><dt>Tanggal</dt><dd>23 September 2025</dd></div>
+                    <div><dt>Durasi baca</dt><dd>±8 menit</dd></div>
+                  </dl>
+                </a>
+              </article>
+            </li>
+            <li>
+              <article class="blog-card">
+                <a class="blog-card__link" href="/blog/panduan-buyback-berlian/">
+                  <span class="blog-card__badge">Panduan</span>
+                  <h3 class="blog-card__title">Panduan Buyback Berlian: Kenali 4C, Bentuk, &amp; Sertifikat</h3>
+                  <p class="blog-card__excerpt">Ketahui standar penilaian berlian, kualitas 4C, serta dokumen yang perlu Anda siapkan ketika menjual berlian via COD.</p>
+                  <dl class="blog-card__meta">
+                    <div><dt>Tanggal</dt><dd>17 September 2025</dd></div>
+                    <div><dt>Durasi baca</dt><dd>±10 menit</dd></div>
+                  </dl>
+                </a>
+              </article>
+            </li>
+          </ul>
           <div class="mt-10"><a class="btn btn-ghost" href="/blog/">Lihat semua artikel Sentral Emas</a></div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- replace the homepage "Panduan & Artikel" cards with an unordered list so each card uses native list semantics
- convert the blog index grid to an unordered list that wraps each article card while preserving the existing styling
- reset default list styles in the shared blog-grid styles to keep spacing identical without relying on ARIA overrides

## Testing
- not run (static site change)

------
https://chatgpt.com/codex/tasks/task_e_68d2e6ca618c833081d3c87bc93850e4