### PR TITLE
Improve LCP image prioritization

### DIFF
--- a/harga/index.html
+++ b/harga/index.html
@@ -60,6 +60,7 @@
     <link rel="preconnect" href="https://wa.me" crossorigin>
     <link rel="dns-prefetch" href="https://www.googletagmanager.com">
     <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+    <link rel="preload" as="image" href="/assets/img/asset1.webp" imagesizes="(max-width: 860px) 100vw, 50vw" imagesrcset="/assets/img/asset1.webp 1200w" media="(min-width: 861px)" fetchpriority="high">
     <link rel="icon" href="/assets/icons/favicon.ico" sizes="32x32" type="image/x-icon"/>
     <link rel="shortcut icon" href="/assets/icons/favicon.ico" type="image/x-icon"/>
     <link rel="icon" href="/assets/icons/logo-48x48.png" type="image/png"/>
@@ -145,7 +146,7 @@
           </div>
           <div>
             <div class="card bling">
-              <img alt="Timbangan emas" src="/assets/img/asset1.webp" decoding="async" loading="lazy" width="1200" height="420"/>
+              <img alt="Timbangan emas" src="/assets/img/asset1.webp" decoding="async" fetchpriority="high" loading="eager" width="1200" height="420"/>
               <i class="shine" aria-hidden="true"></i>
               <i class="sparkle s1" aria-hidden="true"></i>
               <i class="sparkle s2" aria-hidden="true"></i>

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="Sentral Emas">
     
-    <link rel="preload" as="image" href="assets/img/asset1.webp" imagesizes="(max-width: 860px) 100vw, 50vw" imagesrcset="assets/img/asset1.webp 1200w" media="(min-width: 861px)">
+    <link rel="preload" as="image" href="assets/img/asset1.webp" imagesizes="(max-width: 860px) 100vw, 50vw" imagesrcset="assets/img/asset1.webp 1200w" media="(min-width: 861px)" fetchpriority="high">
     <noscript>
       <style>
         .bg-hostess{background-image:url('assets/img/wm.webp');}


### PR DESCRIPTION
## Summary
- elevate the preload priority for the home hero image
- preload the hero asset on the pricing page and load it eagerly with high priority

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d2ea19211c8330ae2a525d86abf46b