### PR TITLE
Defer Google Tag Manager loading

### DIFF
--- a/blog/panduan-buyback-berlian/index.html
+++ b/blog/panduan-buyback-berlian/index.html
@@ -2,11 +2,53 @@
 <html lang="id">
   <head>
     <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5D39RVL3');</script>
+    <script>
+      (function(w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+
+        var loaded = false;
+        var events = ['scroll', 'pointerdown', 'keydown'];
+        var opts = { once: true, passive: true };
+
+        function cleanup() {
+          events.forEach(function(evt) {
+            d.removeEventListener(evt, trigger, opts);
+          });
+        }
+
+        function loadGTM() {
+          if (loaded) {
+            return;
+          }
+          loaded = true;
+          cleanup();
+
+          var f = d.getElementsByTagName(s)[0];
+          var j = d.createElement(s);
+          var dl = l !== 'dataLayer' ? '&l=' + l : '';
+          j.async = true;
+          j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+          f.parentNode.insertBefore(j, f);
+        }
+
+        function trigger() {
+          loadGTM();
+        }
+
+        events.forEach(function(evt) {
+          d.addEventListener(evt, trigger, opts);
+        });
+
+        if (w.requestIdleCallback) {
+          w.requestIdleCallback(function() {
+            loadGTM();
+          }, { timeout: 4000 });
+        } else {
+          w.setTimeout(loadGTM, 4000);
+        }
+      })(window, document, 'script', 'dataLayer', 'GTM-5D39RVL3');
+    </script>
     <!-- End Google Tag Manager -->
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -15,7 +57,7 @@
       content="default-src 'self';
         img-src 'self' data: https://www.google-analytics.com https://www.googletagmanager.com https://www.google.com https://www.google.co.id https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net;
         media-src 'self';
-        script-src 'self' https://pluang.com https://www.googletagmanager.com https://www.google-analytics.com https://www.google.com https://www.gstatic.com https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net 'sha256-VMze8vM9iA5eoGxZgMy2QJAu0Hascu5XdrfQ2zictRE=' 'sha256-lKSmt9/xy5jtn0F2bQ4hRVO7kwPtze8xYlDunJfkX88=' 'sha256-BybwlXa4RsTIZMbwN99QXwHYOG9Gi+1qAWr/wBQIl4M=' 'sha256-5hmGas9SExqwK9qN5Bclww8MuhIW7wONGqJRQ2KXb18=';
+        script-src 'self' https://pluang.com https://www.googletagmanager.com https://www.google-analytics.com https://www.google.com https://www.gstatic.com https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net 'sha256-VMze8vM9iA5eoGxZgMy2QJAu0Hascu5XdrfQ2zictRE=' 'sha256-lKSmt9/xy5jtn0F2bQ4hRVO7kwPtze8xYlDunJfkX88=' 'sha256-BybwlXa4RsTIZMbwN99QXwHYOG9Gi+1qAWr/wBQIl4M=' 'sha256-5hmGas9SExqwK9qN5Bclww8MuhIW7wONGqJRQ2KXb18=' 'sha256-e0OHB/k6PoqORQ9e1lsxcKl8VpFktsSg0qKmkwBZ8Z0=';
         style-src 'self' 'unsafe-inline';
         font-src 'self';
         connect-src 'self' https://pluang.com https://wa.me https://www.google-analytics.com https://www.googletagmanager.com https://www.google.com https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net;

--- a/harga/index.html
+++ b/harga/index.html
@@ -2,11 +2,53 @@
 <html lang="id">
   <head>
     <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5D39RVL3');</script>
+    <script>
+      (function(w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+
+        var loaded = false;
+        var events = ['scroll', 'pointerdown', 'keydown'];
+        var opts = { once: true, passive: true };
+
+        function cleanup() {
+          events.forEach(function(evt) {
+            d.removeEventListener(evt, trigger, opts);
+          });
+        }
+
+        function loadGTM() {
+          if (loaded) {
+            return;
+          }
+          loaded = true;
+          cleanup();
+
+          var f = d.getElementsByTagName(s)[0];
+          var j = d.createElement(s);
+          var dl = l !== 'dataLayer' ? '&l=' + l : '';
+          j.async = true;
+          j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+          f.parentNode.insertBefore(j, f);
+        }
+
+        function trigger() {
+          loadGTM();
+        }
+
+        events.forEach(function(evt) {
+          d.addEventListener(evt, trigger, opts);
+        });
+
+        if (w.requestIdleCallback) {
+          w.requestIdleCallback(function() {
+            loadGTM();
+          }, { timeout: 4000 });
+        } else {
+          w.setTimeout(loadGTM, 4000);
+        }
+      })(window, document, 'script', 'dataLayer', 'GTM-5D39RVL3');
+    </script>
     <!-- End Google Tag Manager -->
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -15,7 +57,7 @@
       content="default-src 'self';
         img-src 'self' data: https://www.google-analytics.com https://www.googletagmanager.com https://www.google.com https://www.google.co.id https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net;
         media-src 'self';
-        script-src 'self' https://pluang.com https://www.googletagmanager.com https://www.google-analytics.com https://www.google.com https://www.gstatic.com https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net 'sha256-VMze8vM9iA5eoGxZgMy2QJAu0Hascu5XdrfQ2zictRE=' 'sha256-lKSmt9/xy5jtn0F2bQ4hRVO7kwPtze8xYlDunJfkX88=' 'sha256-BybwlXa4RsTIZMbwN99QXwHYOG9Gi+1qAWr/wBQIl4M=' 'sha256-5hmGas9SExqwK9qN5Bclww8MuhIW7wONGqJRQ2KXb18=';
+        script-src 'self' https://pluang.com https://www.googletagmanager.com https://www.google-analytics.com https://www.google.com https://www.gstatic.com https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net 'sha256-VMze8vM9iA5eoGxZgMy2QJAu0Hascu5XdrfQ2zictRE=' 'sha256-lKSmt9/xy5jtn0F2bQ4hRVO7kwPtze8xYlDunJfkX88=' 'sha256-BybwlXa4RsTIZMbwN99QXwHYOG9Gi+1qAWr/wBQIl4M=' 'sha256-5hmGas9SExqwK9qN5Bclww8MuhIW7wONGqJRQ2KXb18=' 'sha256-e0OHB/k6PoqORQ9e1lsxcKl8VpFktsSg0qKmkwBZ8Z0=';
         style-src 'self' 'unsafe-inline';
         font-src 'self';
         connect-src 'self' https://pluang.com https://wa.me https://www.google-analytics.com https://www.googletagmanager.com https://www.google.com https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net;

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
       content="default-src 'self';
         img-src 'self' data: https://www.google-analytics.com https://www.googletagmanager.com https://www.google.com https://www.google.co.id https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net;
         media-src 'self';
-        script-src 'self' https://pluang.com https://www.googletagmanager.com https://www.google-analytics.com https://www.google.com https://www.gstatic.com https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net 'sha256-OmpoefMaacLy61S+i7zIyHiferp/ad+4RJSwODcABw4=' 'sha256-y4xXnjmvzpy7oQMw2l4evnsFZevxqtfXecoDCR5CnVU=' 'sha256-W/3/q7VezXXwzZMQxP8QPF6HgSLxhIFVUqnbB6YTmQQ=' 'sha256-DGXoYNDjkpgiN7XSylxGI8Q/NLgDFVTzhCc4+FSBho4=' 'sha256-U+66+q/PLjnT5dp8UVRgUZxG9z6xxCBCl4cdymRvn4Q=' 'sha256-RIF8DAiASgL99gqe+w6X4SLTZFCzkuWnjm2By3u8vv0=' 'sha256-dPg4cXBd21M3BQJX3JytBnvqfwe1ar/fCpDaI7DPhI4=' 'sha256-s5jGOr5xL+rh2kSZySAK1A+3R3HwIk5JY8B959Prq2k=';
+        script-src 'self' https://pluang.com https://www.googletagmanager.com https://www.google-analytics.com https://www.google.com https://www.gstatic.com https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net 'sha256-OmpoefMaacLy61S+i7zIyHiferp/ad+4RJSwODcABw4=' 'sha256-y4xXnjmvzpy7oQMw2l4evnsFZevxqtfXecoDCR5CnVU=' 'sha256-W/3/q7VezXXwzZMQxP8QPF6HgSLxhIFVUqnbB6YTmQQ=' 'sha256-DGXoYNDjkpgiN7XSylxGI8Q/NLgDFVTzhCc4+FSBho4=' 'sha256-U+66+q/PLjnT5dp8UVRgUZxG9z6xxCBCl4cdymRvn4Q=' 'sha256-RIF8DAiASgL99gqe+w6X4SLTZFCzkuWnjm2By3u8vv0=' 'sha256-dPg4cXBd21M3BQJX3JytBnvqfwe1ar/fCpDaI7DPhI4=' 'sha256-e0OHB/k6PoqORQ9e1lsxcKl8VpFktsSg0qKmkwBZ8Z0=' 'sha256-s5jGOr5xL+rh2kSZySAK1A+3R3HwIk5JY8B959Prq2k=';
         style-src 'self' 'unsafe-inline';
         font-src 'self';
         connect-src 'self' https://pluang.com https://wa.me https://www.google-analytics.com https://www.googletagmanager.com https://www.google.com https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net;
@@ -1101,11 +1101,53 @@
       }
     </script>
     <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5D39RVL3');</script>
+    <script>
+      (function(w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+
+        var loaded = false;
+        var events = ['scroll', 'pointerdown', 'keydown'];
+        var opts = { once: true, passive: true };
+
+        function cleanup() {
+          events.forEach(function(evt) {
+            d.removeEventListener(evt, trigger, opts);
+          });
+        }
+
+        function loadGTM() {
+          if (loaded) {
+            return;
+          }
+          loaded = true;
+          cleanup();
+
+          var f = d.getElementsByTagName(s)[0];
+          var j = d.createElement(s);
+          var dl = l !== 'dataLayer' ? '&l=' + l : '';
+          j.async = true;
+          j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+          f.parentNode.insertBefore(j, f);
+        }
+
+        function trigger() {
+          loadGTM();
+        }
+
+        events.forEach(function(evt) {
+          d.addEventListener(evt, trigger, opts);
+        });
+
+        if (w.requestIdleCallback) {
+          w.requestIdleCallback(function() {
+            loadGTM();
+          }, { timeout: 4000 });
+        } else {
+          w.setTimeout(loadGTM, 4000);
+        }
+      })(window, document, 'script', 'dataLayer', 'GTM-5D39RVL3');
+    </script>
     <!-- End Google Tag Manager -->
     <script src="assets/js/main.js" defer></script>
   </body>


### PR DESCRIPTION
## Summary
- defer Google Tag Manager loading on the main, harga, and blog pages until user interaction or idle time to cut unused JavaScript
- update each page's Content-Security-Policy hash list to authorize the new loader snippet

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d2eb22df3c833080f17beaeceecb3b