### PR TITLE
Enhance highlight card on harga page

### DIFF
--- a/harga/index.html
+++ b/harga/index.html
@@ -175,7 +175,15 @@
             <h2 id="lmHighlightTitle" class="h2">Pergerakan Harga Buyback Harian</h2>
           </div>
         </div>
-        <div id="lmBaruHighlight" class="card price-highlight" role="status" aria-live="polite">
+        <div id="lmBaruHighlight" class="card price-highlight" role="status" aria-live="polite" aria-busy="true" aria-describedby="lmBaruDeltaText lmBaruTrendSummary">
+          <div class="skeleton-content" aria-hidden="true">
+            <div class="flex-split">
+              <div class="skeleton skeleton-line" style="width: 150px; height: 1.1rem;"></div>
+              <div class="skeleton skeleton-badge"></div>
+            </div>
+            <div class="skeleton skeleton-price" style="height: 2.4rem; width: 200px; margin-top: .2rem;"></div>
+            <div class="skeleton skeleton-delta" style="width: 240px;"></div>
+          </div>
           <div class="price-highlight-head">
             <p class="price-highlight-label">Logam Mulia (LM) Baru</p>
             <span id="lmBaruTrendBadge" class="price-badge price-neutral">Menunggu</span>
@@ -184,6 +192,14 @@
             <span id="lmBaruCurrent" class="price-highlight-value">Rp —</span>
             <span class="price-highlight-unit">/gram</span>
           </div>
+          <div class="price-highlight-chart">
+            <canvas id="lmBaruSparkline" height="60" aria-hidden="true" role="img" tabindex="0" aria-describedby="lmBaruTrendSummary lmBaruSparklinePointSummary"></canvas>
+            <div id="lmBaruSparklineMarker" class="sparkline-marker" aria-hidden="true"></div>
+            <div id="lmBaruSparklineTooltip" class="sparkline-tooltip" role="tooltip" aria-hidden="true"></div>
+            <div id="lmBaruChartFallback" class="chart-fallback is-visible" role="note">Grafik menunggu data riwayat harga.</div>
+          </div>
+          <p id="lmBaruTrendSummary" class="sr-only">Ringkasan tren 7 hari: menunggu data riwayat harga.</p>
+          <p id="lmBaruSparklinePointSummary" class="sr-only" aria-live="polite"></p>
           <div class="price-highlight-delta" id="lmBaruDelta">
             <span class="delta-icon" aria-hidden="true">-</span>
             <span id="lmBaruDeltaText">Selisih menunggu data</span>


### PR DESCRIPTION
## Summary
- sync the harga page LM highlight card layout with the homepage implementation
- add skeleton loading state, sparkline canvas, and accessibility helpers for the buyback highlight

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d95c5b41608330b942d7a58c6714ef