### PR TITLE
Add range toggle and insights to LM highlight card

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2312,6 +2312,65 @@ tbody tr:hover td {
   color: var(--paper)
 }
 
+.price-highlight-insight-value--stack {
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+}
+
+.price-highlight-insight-value--stack > span:first-child {
+  font-size: 1.02rem;
+  line-height: 1.25;
+}
+
+.price-highlight-compare-delta {
+  display: inline-flex;
+  align-items: center;
+  gap: .3rem;
+  font-size: .78rem;
+  font-weight: 600;
+  padding: .25rem .6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, .12);
+  color: var(--paper);
+  letter-spacing: .01em;
+  text-transform: none;
+  transition: background .3s ease, color .3s ease, transform .3s ease;
+}
+
+.price-highlight-compare-delta::before {
+  content: '';
+  display: inline-block;
+  width: .5rem;
+  height: .5rem;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: .9;
+}
+
+.price-highlight-compare-delta[data-trend="up"] {
+  background: linear-gradient(135deg, rgba(88, 255, 169, .32), rgba(16, 130, 101, .42));
+  color: #012e24;
+}
+
+.price-highlight-compare-delta[data-trend="down"] {
+  background: linear-gradient(135deg, rgba(255, 179, 164, .36), rgba(214, 72, 58, .52));
+  color: #fff4f1;
+}
+
+.price-highlight-compare-delta[data-trend="flat"] {
+  background: rgba(255, 255, 255, .16);
+  color: var(--paper);
+}
+
+.price-highlight-compare-delta[data-trend="pending"] {
+  opacity: .7;
+}
+
+.price-highlight-insight--compare .price-highlight-insight-value {
+  font-size: 1.02rem;
+}
+
 .price-highlight-delta {
   display: flex;
   align-items: center;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2000,7 +2000,7 @@ tbody tr:hover td {
   max-width: 800px;
   display: flex;
   flex-direction: column;
-  gap: .6rem;
+  gap: .9rem;
   transition: transform .3s ease, box-shadow .3s ease
 }
 
@@ -2025,44 +2025,117 @@ tbody tr:hover td {
 
 .price-highlight-head {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: .8rem
+}
+
+.price-highlight-headline {
+  display: flex;
+  flex-direction: column;
+  gap: .35rem
 }
 
 .price-highlight-label {
   margin: 0;
   text-transform: uppercase;
-  letter-spacing: .08em;
+  letter-spacing: .1em;
   font-weight: 700;
   font-size: .82rem;
-  color: var(--paper)
+  color: rgba(239, 255, 252, .92)
+}
+
+.price-highlight-controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: .6rem;
+  flex-wrap: wrap;
+  margin-left: auto
+}
+
+.price-range-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: .2rem;
+  padding: .25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, .22);
+  background: linear-gradient(135deg, rgba(255, 255, 255, .12), rgba(255, 255, 255, .02));
+  box-shadow: 0 12px 26px rgba(1, 25, 23, .24);
+  backdrop-filter: blur(8px)
+}
+
+.price-range-btn {
+  appearance: none;
+  border: 0;
+  border-radius: 999px;
+  padding: .35rem .85rem;
+  font-weight: 600;
+  font-size: .78rem;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+  background: transparent;
+  color: rgba(224, 248, 244, .78);
+  cursor: pointer;
+  transition: color .2s ease, background .2s ease, box-shadow .2s ease, transform .2s ease
+}
+
+.price-range-btn:hover {
+  color: rgba(255, 255, 255, .92)
+}
+
+.price-range-btn.is-active,
+.price-range-btn[aria-pressed="true"] {
+  background: linear-gradient(135deg, rgba(88, 255, 169, .85), rgba(18, 163, 134, .72));
+  color: #012c24;
+  box-shadow: 0 14px 28px rgba(12, 143, 100, .34);
+  transform: translateY(-1px)
+}
+
+.price-range-btn:focus-visible {
+  outline: 2px solid rgba(212, 175, 55, .65);
+  outline-offset: 2px
 }
 
 .price-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: .2rem .6rem;
+  padding: .3rem .9rem;
   border-radius: 999px;
   font-weight: 700;
   font-size: .78rem;
-  min-width: 96px
+  letter-spacing: .09em;
+  text-transform: uppercase;
+  min-width: 0;
+  border: 1px solid rgba(255, 255, 255, .28);
+  background: linear-gradient(135deg, rgba(255, 255, 255, .24), rgba(255, 255, 255, .06));
+  color: var(--paper);
+  box-shadow: 0 16px 32px rgba(1, 25, 23, .3);
+  white-space: nowrap;
+  transition: transform .2s ease, box-shadow .2s ease
 }
 
 .price-badge.price-up {
-  background: rgba(14, 156, 90, .2);
-  color: #58ffa9
+  background: linear-gradient(135deg, rgba(88, 255, 169, .62), rgba(16, 130, 101, .78));
+  color: #012e24;
+  border-color: rgba(88, 255, 169, .64);
+  box-shadow: 0 18px 32px rgba(11, 110, 87, .35)
 }
 
 .price-badge.price-down {
-  background: rgba(212, 80, 64, .18);
-  color: #ff9f94
+  background: linear-gradient(135deg, rgba(255, 179, 164, .52), rgba(214, 72, 58, .68));
+  color: #fff4f1;
+  border-color: rgba(255, 179, 164, .6);
+  box-shadow: 0 18px 32px rgba(142, 24, 16, .35)
 }
 
 .price-badge.price-neutral {
-  background: rgba(255, 255, 255, .16);
-  color: var(--paper)
+  background: linear-gradient(135deg, rgba(255, 255, 255, .2), rgba(255, 255, 255, .05));
+  color: var(--paper);
+  border-color: rgba(255, 255, 255, .26)
 }
 
 .price-highlight-main {
@@ -2206,14 +2279,53 @@ tbody tr:hover td {
   color: var(--paper)
 }
 
+
+.price-highlight-insights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: .75rem;
+  margin: .1rem 0 .3rem
+}
+
+.price-highlight-insight {
+  padding: .7rem .9rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, .14);
+  background: linear-gradient(140deg, rgba(255, 255, 255, .1), rgba(1, 31, 29, .18));
+  box-shadow: 0 16px 30px rgba(1, 25, 23, .22);
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: .2rem
+}
+
+.price-highlight-insight-label {
+  font-size: .68rem;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: rgba(225, 250, 246, .76)
+}
+
+.price-highlight-insight-value {
+  font-size: 1.02rem;
+  font-weight: 700;
+  color: var(--paper)
+}
+
 .price-highlight-delta {
   display: flex;
   align-items: center;
-  gap: .6rem;
+  gap: .75rem;
+  flex-wrap: wrap;
   font-weight: 600;
   font-size: .95rem;
   color: var(--paper);
-  transition: transform .3s ease
+  transition: transform .3s ease;
+  padding: .7rem .9rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, .07);
+  border: 1px solid rgba(255, 255, 255, .1);
+  box-shadow: 0 18px 34px rgba(1, 25, 23, .22)
 }
 
 .price-highlight-delta.delta-flash {
@@ -2221,17 +2333,18 @@ tbody tr:hover td {
 }
 
 .price-highlight-delta .delta-icon {
-  width: 30px;
-  height: 30px;
+  width: 34px;
+  height: 34px;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(255, 255, 255, .16);
+  background: rgba(255, 255, 255, .2);
   color: var(--paper);
   position: relative;
   overflow: hidden;
-  font-size: 0
+  font-size: 0;
+  box-shadow: 0 12px 22px rgba(0, 0, 0, .28)
 }
 
 .price-highlight-delta .delta-icon::before,
@@ -2311,29 +2424,37 @@ tbody tr:hover td {
 }
 
 .price-highlight-delta.trend-up {
-  color: #58ffa9
+  color: #58ffa9;
+  background: linear-gradient(135deg, rgba(88, 255, 169, .2), rgba(16, 130, 101, .18));
+  border-color: rgba(88, 255, 169, .32)
 }
 
 .price-highlight-delta.trend-up .delta-icon {
-  background: rgba(14, 156, 90, .24);
-  color: #58ffa9
+  background: linear-gradient(135deg, rgba(88, 255, 169, .78), rgba(16, 130, 101, .64));
+  color: #012d23;
+  box-shadow: 0 14px 26px rgba(11, 110, 87, .35)
 }
 
 .price-highlight-delta.trend-down {
-  color: #ff9f94
+  color: #ffb3a8;
+  background: linear-gradient(135deg, rgba(255, 179, 164, .24), rgba(214, 72, 58, .16));
+  border-color: rgba(255, 179, 164, .3)
 }
 
 .price-highlight-delta.trend-down .delta-icon {
-  background: rgba(212, 80, 64, .26);
-  color: #ff9f94
+  background: linear-gradient(135deg, rgba(255, 179, 164, .68), rgba(214, 72, 58, .62));
+  color: #5c0b02;
+  box-shadow: 0 14px 26px rgba(142, 24, 16, .32)
 }
 
 .price-highlight-delta.trend-flat {
-  color: var(--paper)
+  color: var(--paper);
+  background: linear-gradient(135deg, rgba(255, 255, 255, .16), rgba(255, 255, 255, .08));
+  border-color: rgba(255, 255, 255, .16)
 }
 
 .price-highlight-delta.trend-flat .delta-icon {
-  background: rgba(255, 255, 255, .18);
+  background: rgba(255, 255, 255, .2);
   color: var(--paper)
 }
 
@@ -2363,6 +2484,21 @@ tbody tr:hover td {
 
   .price-badge {
     min-width: 0
+  }
+
+  .price-highlight-controls {
+    width: 100%;
+    margin-left: 0;
+    justify-content: space-between
+  }
+
+  .price-range-toggle {
+    width: 100%;
+    justify-content: space-between
+  }
+
+  .price-range-btn {
+    flex: 1
   }
 }
 
@@ -4552,7 +4688,9 @@ a {
 #lmBaruHighlight[aria-busy="true"] .price-highlight-head,
 #lmBaruHighlight[aria-busy="true"] .price-highlight-main,
 #lmBaruHighlight[aria-busy="true"] .price-highlight-chart,
-#lmBaruHighlight[aria-busy="true"] .price-highlight-delta {
+#lmBaruHighlight[aria-busy="true"] .price-highlight-insights,
+#lmBaruHighlight[aria-busy="true"] .price-highlight-delta,
+#lmBaruHighlight[aria-busy="true"] .price-highlight-actions {
   visibility: hidden;
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1623,6 +1623,59 @@ function refreshRangeMetrics(series, meta) {
   var max = values.length ? Math.max.apply(null, values) : null;
   if (lowEl) lowEl.textContent = min !== null ? 'Rp ' + formatCurrencyIDR(min) : 'Rp —';
   if (highEl) highEl.textContent = max !== null ? 'Rp ' + formatCurrencyIDR(max) : 'Rp —';
+
+  var compareLabelEl = document.getElementById('lmBaruRangeCompareLabel');
+  var compareValueEl = document.getElementById('lmBaruRangeCompareValue');
+  var compareDeltaEl = document.getElementById('lmBaruRangeCompareDelta');
+  var compareWrap = document.getElementById('lmBaruRangeCompare');
+  var firstPrice = null;
+  var lastPrice = null;
+
+  if (Array.isArray(series)) {
+    for (var idx = 0; idx < series.length; idx++) {
+      var candidate = series[idx];
+      if (!candidate || typeof candidate.price !== 'number' || !isFinite(candidate.price)) continue;
+      var rounded = Math.round(candidate.price);
+      if (firstPrice === null) firstPrice = rounded;
+      lastPrice = rounded;
+    }
+  }
+
+  var compareLabelText = 'Harga Awal Rentang';
+  if (config && typeof config.days === 'number' && config.days > 0) {
+    compareLabelText = 'Harga ' + config.days + ' Hari Lalu';
+  }
+  if (compareLabelEl) compareLabelEl.textContent = compareLabelText;
+  if (compareValueEl) {
+    compareValueEl.textContent = firstPrice !== null ? 'Rp ' + formatCurrencyIDR(firstPrice) : 'Rp —';
+  }
+
+  var deltaState = 'pending';
+  var deltaText = 'Menunggu data rentang';
+  if (firstPrice !== null && lastPrice !== null) {
+    var diff = lastPrice - firstPrice;
+    var absDiff = Math.abs(diff);
+    if (diff > 0) {
+      deltaState = 'up';
+      deltaText = 'Naik Rp ' + formatCurrencyIDR(absDiff) + ' dibanding awal rentang';
+    } else if (diff < 0) {
+      deltaState = 'down';
+      deltaText = 'Turun Rp ' + formatCurrencyIDR(absDiff) + ' dibanding awal rentang';
+    } else {
+      deltaState = 'flat';
+      deltaText = 'Stabil dibanding awal rentang';
+    }
+  }
+  if (compareDeltaEl) {
+    compareDeltaEl.textContent = deltaText;
+    compareDeltaEl.setAttribute('data-trend', deltaState);
+  }
+  if (compareWrap) {
+    compareWrap.setAttribute('data-trend', deltaState);
+  }
+  if (highlightCard) {
+    highlightCard.setAttribute('data-range-compare-trend', deltaState);
+  }
   updateRangeToggleState(activeKey);
 }
 
@@ -4341,6 +4394,7 @@ if (typeof window !== 'undefined') {
   testingApi.saveLastBasePrice = saveLastBasePrice;
   testingApi.readLastBasePrice = readLastBasePrice;
   testingApi.updatePriceSchema = updatePriceSchema;
+  testingApi.refreshRangeMetrics = refreshRangeMetrics;
   testingApi.displayFromBasePrice = displayFromBasePrice;
   testingApi.fetchGoldPrice = fetchGoldPrice;
   testingApi.displayDefaultPrices = displayDefaultPrices;
@@ -4360,6 +4414,7 @@ if (typeof module !== 'undefined' && module.exports) {
     saveLastBasePrice,
     readLastBasePrice,
     updatePriceSchema,
+    refreshRangeMetrics,
     displayFromBasePrice,
     fetchGoldPrice,
     displayDefaultPrices,

--- a/assets/js/main.test.js
+++ b/assets/js/main.test.js
@@ -67,14 +67,44 @@ describe('main.js behaviours', () => {
       <div id="currentDateTime"></div>
       <div id="typer"></div>
       <table><tbody id="goldPriceTable"></tbody></table>
-      <div id="lmBaruHighlight" class="price-highlight">
+      <div id="lmBaruHighlight" class="price-highlight" aria-busy="true" aria-describedby="lmBaruDeltaText lmBaruTrendSummary">
         <div class="price-highlight-head">
-          <p class="price-highlight-label">Logam Mulia (LM) Baru</p>
-          <span id="lmBaruTrendBadge" class="price-badge price-neutral">Menunggu</span>
+          <div class="price-highlight-headline">
+            <p class="price-highlight-label">Logam Mulia (LM) Baru</p>
+          </div>
+          <div class="price-highlight-controls">
+            <div id="lmBaruRangeToggle" class="price-range-toggle" role="group" aria-label="Rentang riwayat harga">
+              <button type="button" class="price-range-btn is-active" data-range="7" aria-pressed="true">7 Hari</button>
+              <button type="button" class="price-range-btn" data-range="30" aria-pressed="false">30 Hari</button>
+            </div>
+            <span id="lmBaruTrendBadge" class="price-badge price-neutral">Menunggu</span>
+          </div>
         </div>
         <div class="price-highlight-main">
           <span id="lmBaruCurrent" class="price-highlight-value">Rp —</span>
           <span class="price-highlight-unit">/gram</span>
+        </div>
+        <div class="price-highlight-chart">
+          <canvas id="lmBaruSparkline" height="60"></canvas>
+          <div id="lmBaruSparklineMarker" class="sparkline-marker"></div>
+          <div id="lmBaruSparklineTooltip" class="sparkline-tooltip"></div>
+          <div id="lmBaruChartFallback" class="chart-fallback is-visible">Grafik menunggu data riwayat harga.</div>
+        </div>
+        <p id="lmBaruTrendSummary" class="sr-only">Ringkasan tren: menunggu data riwayat harga.</p>
+        <p id="lmBaruSparklinePointSummary" class="sr-only" aria-live="polite"></p>
+        <div class="price-highlight-insights">
+          <div class="price-highlight-insight">
+            <span class="price-highlight-insight-label">Rentang</span>
+            <span id="lmBaruRangeValue" class="price-highlight-insight-value">7 Hari Terakhir</span>
+          </div>
+          <div class="price-highlight-insight">
+            <span class="price-highlight-insight-label">Terendah</span>
+            <span id="lmBaruRangeLow" class="price-highlight-insight-value">Rp —</span>
+          </div>
+          <div class="price-highlight-insight">
+            <span class="price-highlight-insight-label">Tertinggi</span>
+            <span id="lmBaruRangeHigh" class="price-highlight-insight-value">Rp —</span>
+          </div>
         </div>
         <div id="lmBaruDelta" class="price-highlight-delta">
           <span class="delta-icon" data-trend="pending"></span>

--- a/assets/js/main.test.js
+++ b/assets/js/main.test.js
@@ -105,6 +105,13 @@ describe('main.js behaviours', () => {
             <span class="price-highlight-insight-label">Tertinggi</span>
             <span id="lmBaruRangeHigh" class="price-highlight-insight-value">Rp —</span>
           </div>
+          <div class="price-highlight-insight price-highlight-insight--compare" id="lmBaruRangeCompare" data-trend="pending">
+            <span id="lmBaruRangeCompareLabel" class="price-highlight-insight-label">Harga 7 Hari Lalu</span>
+            <div class="price-highlight-insight-value price-highlight-insight-value--stack">
+              <span id="lmBaruRangeCompareValue">Rp —</span>
+              <span id="lmBaruRangeCompareDelta" class="price-highlight-compare-delta" data-trend="pending">Menunggu data rentang</span>
+            </div>
+          </div>
         </div>
         <div id="lmBaruDelta" class="price-highlight-delta">
           <span class="delta-icon" data-trend="pending"></span>
@@ -532,6 +539,32 @@ describe('main.js behaviours', () => {
     highlightAdd.click();
     expect(calcSpy).toHaveBeenCalledWith(expect.objectContaining({ cat: 'lm_baru', kadar: '24' }));
     calcSpy.mockRestore();
+  });
+
+  test('refreshRangeMetrics updates comparison insight for active range', async () => {
+    await loadMain();
+    const highlight = document.getElementById('lmBaruHighlight');
+    const series = [{ price: 2000000 }, { price: 2100000 }];
+
+    window.testing.refreshRangeMetrics(series, {
+      rangeKey: '7',
+      rangeConfig: {
+        key: '7',
+        days: 7,
+        label: '7 hari terakhir',
+        displayLabel: '7 Hari Terakhir'
+      }
+    });
+
+    const compareLabel = document.getElementById('lmBaruRangeCompareLabel');
+    const compareValue = document.getElementById('lmBaruRangeCompareValue');
+    const compareDelta = document.getElementById('lmBaruRangeCompareDelta');
+
+    expect(compareLabel.textContent).toBe('Harga 7 Hari Lalu');
+    expect(compareValue.textContent).toBe('Rp 2.000.000');
+    expect(compareDelta.textContent).toContain('Naik Rp 100.000');
+    expect(compareDelta.getAttribute('data-trend')).toBe('up');
+    expect(highlight.getAttribute('data-range-compare-trend')).toBe('up');
   });
 
   test('displayFromBasePrice survives toLocaleString failures', async () => {

--- a/harga/index.html
+++ b/harga/index.html
@@ -222,6 +222,13 @@
               <span class="price-highlight-insight-label">Tertinggi</span>
               <span id="lmBaruRangeHigh" class="price-highlight-insight-value">Rp —</span>
             </div>
+            <div class="price-highlight-insight price-highlight-insight--compare" id="lmBaruRangeCompare" data-trend="pending">
+              <span id="lmBaruRangeCompareLabel" class="price-highlight-insight-label">Harga 7 Hari Lalu</span>
+              <div class="price-highlight-insight-value price-highlight-insight-value--stack">
+                <span id="lmBaruRangeCompareValue">Rp —</span>
+                <span id="lmBaruRangeCompareDelta" class="price-highlight-compare-delta" data-trend="pending">Menunggu data rentang</span>
+              </div>
+            </div>
           </div>
           <div class="price-highlight-delta" id="lmBaruDelta">
             <span class="delta-icon" aria-hidden="true">-</span>

--- a/harga/index.html
+++ b/harga/index.html
@@ -175,18 +175,63 @@
             <h2 id="lmHighlightTitle" class="h2">Pergerakan Harga Buyback Harian</h2>
           </div>
         </div>
-        <div id="lmBaruHighlight" class="card price-highlight" role="status" aria-live="polite">
+        <div id="lmBaruHighlight" class="card price-highlight" role="status" aria-live="polite" aria-busy="true" aria-describedby="lmBaruDeltaText lmBaruTrendSummary">
+          <div class="skeleton-content" aria-hidden="true">
+            <div class="flex-split">
+              <div class="skeleton skeleton-line" style="width: 150px; height: 1.1rem;"></div>
+              <div class="skeleton skeleton-badge"></div>
+            </div>
+            <div class="skeleton skeleton-price" style="height: 2.4rem; width: 200px; margin-top: .2rem;"></div>
+            <div class="skeleton skeleton-delta" style="width: 240px;"></div>
+            <div class="skeleton skeleton-line" style="width: 100%; height: 52px; margin-top: .8rem;"></div>
+          </div>
           <div class="price-highlight-head">
-            <p class="price-highlight-label">Logam Mulia (LM) Baru</p>
-            <span id="lmBaruTrendBadge" class="price-badge price-neutral">Menunggu</span>
+            <div class="price-highlight-headline">
+              <p class="price-highlight-label">Logam Mulia (LM) Baru</p>
+            </div>
+            <div class="price-highlight-controls">
+              <div id="lmBaruRangeToggle" class="price-range-toggle" role="group" aria-label="Rentang riwayat harga">
+                <button type="button" class="price-range-btn is-active" data-range="7" aria-pressed="true">7 Hari</button>
+                <button type="button" class="price-range-btn" data-range="30" aria-pressed="false">30 Hari</button>
+              </div>
+              <span id="lmBaruTrendBadge" class="price-badge price-neutral">Menunggu</span>
+            </div>
           </div>
           <div class="price-highlight-main">
             <span id="lmBaruCurrent" class="price-highlight-value">Rp —</span>
             <span class="price-highlight-unit">/gram</span>
           </div>
+          <div class="price-highlight-chart">
+            <canvas id="lmBaruSparkline" height="60" aria-hidden="true" role="img" tabindex="0" aria-describedby="lmBaruTrendSummary lmBaruSparklinePointSummary"></canvas>
+            <div id="lmBaruSparklineMarker" class="sparkline-marker" aria-hidden="true"></div>
+            <div id="lmBaruSparklineTooltip" class="sparkline-tooltip" role="tooltip" aria-hidden="true"></div>
+            <div id="lmBaruChartFallback" class="chart-fallback is-visible" role="note">Grafik menunggu data riwayat harga.</div>
+          </div>
+          <p id="lmBaruTrendSummary" class="sr-only">Ringkasan tren: menunggu data riwayat harga.</p>
+          <p id="lmBaruSparklinePointSummary" class="sr-only" aria-live="polite"></p>
+          <div class="price-highlight-insights" aria-live="polite">
+            <div class="price-highlight-insight">
+              <span class="price-highlight-insight-label">Rentang</span>
+              <span id="lmBaruRangeValue" class="price-highlight-insight-value">7 Hari Terakhir</span>
+            </div>
+            <div class="price-highlight-insight">
+              <span class="price-highlight-insight-label">Terendah</span>
+              <span id="lmBaruRangeLow" class="price-highlight-insight-value">Rp —</span>
+            </div>
+            <div class="price-highlight-insight">
+              <span class="price-highlight-insight-label">Tertinggi</span>
+              <span id="lmBaruRangeHigh" class="price-highlight-insight-value">Rp —</span>
+            </div>
+          </div>
           <div class="price-highlight-delta" id="lmBaruDelta">
             <span class="delta-icon" aria-hidden="true">-</span>
             <span id="lmBaruDeltaText">Selisih menunggu data</span>
+          </div>
+          <div class="price-highlight-actions">
+            <button id="highlight-add" type="button" class="price-highlight-add" data-add-cat="lm_baru" data-add-kadar="24">
+              <span class="price-add-icon" aria-hidden="true">+</span>
+              <span>Masukkan ke Kalkulator</span>
+            </button>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -256,10 +256,19 @@
             </div>
             <div class="skeleton skeleton-price" style="height: 2.4rem; width: 200px; margin-top: .2rem;"></div>
             <div class="skeleton skeleton-delta" style="width: 240px;"></div>
+            <div class="skeleton skeleton-line" style="width: 100%; height: 52px; margin-top: .8rem;"></div>
           </div>
           <div class="price-highlight-head">
-            <p class="price-highlight-label">Logam Mulia (LM) Baru</p>
-            <span id="lmBaruTrendBadge" class="price-badge price-neutral">Menunggu</span>
+            <div class="price-highlight-headline">
+              <p class="price-highlight-label">Logam Mulia (LM) Baru</p>
+            </div>
+            <div class="price-highlight-controls">
+              <div id="lmBaruRangeToggle" class="price-range-toggle" role="group" aria-label="Rentang riwayat harga">
+                <button type="button" class="price-range-btn is-active" data-range="7" aria-pressed="true">7 Hari</button>
+                <button type="button" class="price-range-btn" data-range="30" aria-pressed="false">30 Hari</button>
+              </div>
+              <span id="lmBaruTrendBadge" class="price-badge price-neutral">Menunggu</span>
+            </div>
           </div>
           <div class="price-highlight-main">
             <span id="lmBaruCurrent" class="price-highlight-value">Rp —</span>
@@ -271,11 +280,31 @@
             <div id="lmBaruSparklineTooltip" class="sparkline-tooltip" role="tooltip" aria-hidden="true"></div>
             <div id="lmBaruChartFallback" class="chart-fallback is-visible" role="note">Grafik menunggu data riwayat harga.</div>
           </div>
-          <p id="lmBaruTrendSummary" class="sr-only">Ringkasan tren 7 hari: menunggu data riwayat harga.</p>
+          <p id="lmBaruTrendSummary" class="sr-only">Ringkasan tren: menunggu data riwayat harga.</p>
           <p id="lmBaruSparklinePointSummary" class="sr-only" aria-live="polite"></p>
+          <div class="price-highlight-insights" aria-live="polite">
+            <div class="price-highlight-insight">
+              <span class="price-highlight-insight-label">Rentang</span>
+              <span id="lmBaruRangeValue" class="price-highlight-insight-value">7 Hari Terakhir</span>
+            </div>
+            <div class="price-highlight-insight">
+              <span class="price-highlight-insight-label">Terendah</span>
+              <span id="lmBaruRangeLow" class="price-highlight-insight-value">Rp —</span>
+            </div>
+            <div class="price-highlight-insight">
+              <span class="price-highlight-insight-label">Tertinggi</span>
+              <span id="lmBaruRangeHigh" class="price-highlight-insight-value">Rp —</span>
+            </div>
+          </div>
           <div class="price-highlight-delta" id="lmBaruDelta">
             <span class="delta-icon" aria-hidden="true">-</span>
             <span id="lmBaruDeltaText">Selisih menunggu data</span>
+          </div>
+          <div class="price-highlight-actions">
+            <button id="highlight-add" type="button" class="price-highlight-add" data-add-cat="lm_baru" data-add-kadar="24">
+              <span class="price-add-icon" aria-hidden="true">+</span>
+              <span>Masukkan ke Kalkulator</span>
+            </button>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -295,6 +295,13 @@
               <span class="price-highlight-insight-label">Tertinggi</span>
               <span id="lmBaruRangeHigh" class="price-highlight-insight-value">Rp —</span>
             </div>
+            <div class="price-highlight-insight price-highlight-insight--compare" id="lmBaruRangeCompare" data-trend="pending">
+              <span id="lmBaruRangeCompareLabel" class="price-highlight-insight-label">Harga 7 Hari Lalu</span>
+              <div class="price-highlight-insight-value price-highlight-insight-value--stack">
+                <span id="lmBaruRangeCompareValue">Rp —</span>
+                <span id="lmBaruRangeCompareDelta" class="price-highlight-compare-delta" data-trend="pending">Menunggu data rentang</span>
+              </div>
+            </div>
           </div>
           <div class="price-highlight-delta" id="lmBaruDelta">
             <span class="delta-icon" aria-hidden="true">-</span>


### PR DESCRIPTION
## Summary
- add 7/30 day range toggle, chart markup, and range stats to the LM highlight card on both the homepage and harga page
- extend the pricing script to manage range selection, cache series per range, and update lowest/highest metrics along with sparkline rendering
- refresh highlight styling for the new controls, insight chips, and trend badges for a more polished presentation

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d9716ca5988330bced65940e043e67