### PR TITLE
Add animated timeline for value steps section

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3664,7 +3664,9 @@ a {
   box-shadow: var(--shadow);
   display: flex;
   flex-direction: column;
-  gap: 1.1rem
+  gap: 1.1rem;
+  position: relative;
+  overflow: hidden
 }
 
 .value-steps h3 {
@@ -3679,14 +3681,32 @@ a {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 1.1rem
+  gap: 1.1rem;
+  position: relative
+}
+
+.value-steps ol::before {
+  content: "";
+  position: absolute;
+  top: 19px;
+  bottom: 19px;
+  left: 19px;
+  width: 2px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(212, 175, 55, 0), rgba(212, 175, 55, .52) 38%, rgba(212, 175, 55, .82));
+  transform-origin: top;
+  opacity: 1;
+  transform: scaleY(1)
 }
 
 .value-steps li {
   display: flex;
   gap: 1rem;
   border-bottom: 1px solid var(--border-subtle);
-  padding-bottom: 1rem
+  padding-bottom: 1rem;
+  align-items: flex-start;
+  opacity: 1;
+  transform: none
 }
 
 .value-steps li:last-child {
@@ -3715,7 +3735,49 @@ a {
   place-items: center;
   background: rgba(212, 175, 55, .24);
   color: var(--accent-green);
-  font-weight: 700
+  font-weight: 700;
+  position: relative;
+  z-index: 1
+}
+
+.value-steps.is-animated ol::before {
+  animation: timelineGrow 1.15s cubic-bezier(.33, 1, .68, 1) forwards
+}
+
+.value-steps.is-animated li {
+  animation: stepReveal .65s ease forwards
+}
+
+.value-steps.is-animated li:nth-child(2) {
+  animation-delay: .12s
+}
+
+.value-steps.is-animated li:nth-child(3) {
+  animation-delay: .24s
+}
+
+@keyframes timelineGrow {
+  0% {
+    transform: scaleY(0);
+    opacity: 0
+  }
+
+  100% {
+    transform: scaleY(1);
+    opacity: 1
+  }
+}
+
+@keyframes stepReveal {
+  0% {
+    opacity: 0;
+    transform: translateY(18px)
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0)
+  }
 }
 
 @media (max-width:980px) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -806,6 +806,26 @@ if (typeof window !== 'undefined') {
   } else {
     revealables.forEach(el => el.classList.add('visible'));
   }
+
+  const timeline = document.querySelector('.value-steps');
+  if (timeline) {
+    const activateTimeline = () => timeline.classList.add('is-animated');
+    if ('IntersectionObserver' in window) {
+      const timelineObserver = new IntersectionObserver((entries, observer) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            activateTimeline();
+            observer.unobserve(entry.target);
+          }
+        });
+      }, {
+        threshold: .25
+      });
+      timelineObserver.observe(timeline);
+    } else {
+      activateTimeline();
+    }
+  }
   // Date badge minute tick glow
   const badge = document.getElementById('currentDateTime');
   if (badge) {


### PR DESCRIPTION
## Summary
- style the value-steps list with a vertical timeline and staged entry animation
- trigger the new animation when the section scrolls into view via IntersectionObserver logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dff61bc74483308aa43eebc1cdb944