### PR TITLE
Add onboarding wizard for personalized experience

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -6092,3 +6092,296 @@ a {
     opacity: 1;
   }
 }
+
+.onboarding-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1rem, 3vw, 2.5rem);
+  background: rgba(1, 61, 57, .62);
+  z-index: 5000;
+}
+
+.onboarding-overlay[hidden] {
+  display: none !important;
+}
+
+.onboarding-overlay__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(1, 61, 57, .55);
+}
+
+.onboarding-dialog {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 540px);
+  border-radius: 20px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  box-shadow: 0 32px 70px rgba(0, 0, 0, .25);
+  padding: clamp(1.6rem, 2.5vw, 2.4rem);
+}
+
+body.onboarding-is-open {
+  overflow: hidden;
+}
+
+.onboarding-close {
+  position: absolute;
+  top: .8rem;
+  right: .8rem;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 1.6rem;
+  line-height: 1;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform .2s ease;
+}
+
+.onboarding-close:hover {
+  transform: scale(1.05);
+}
+
+.onboarding-progress {
+  display: inline-flex;
+  align-items: center;
+  gap: .35rem;
+  font-size: .75rem;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+.onboarding-title {
+  margin-top: .6rem;
+  margin-bottom: .6rem;
+  font-size: 1.45rem;
+  line-height: 1.3;
+}
+
+.onboarding-summary {
+  margin: 0 0 1.5rem;
+  color: var(--text-secondary);
+  font-size: .95rem;
+}
+
+.onboarding-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.onboarding-step[hidden] {
+  display: none !important;
+}
+
+.onboarding-fieldset {
+  margin: 0;
+  padding: 0;
+  border: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.onboarding-legend {
+  font-weight: 700;
+  font-size: 1.05rem;
+  margin-bottom: .5rem;
+}
+
+.onboarding-options {
+  display: grid;
+  gap: 1rem;
+}
+
+.onboarding-option {
+  display: block;
+  cursor: pointer;
+}
+
+.onboarding-option input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.onboarding-option__box {
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+  padding: 1rem 1.15rem;
+  border-radius: 14px;
+  border: 1px solid rgba(1, 61, 57, .12);
+  background: var(--bg-secondary);
+  transition: border-color .2s ease, box-shadow .2s ease, transform .2s ease;
+}
+
+.onboarding-option__title {
+  font-weight: 600;
+}
+
+.onboarding-option__desc {
+  font-size: .85rem;
+  color: var(--text-muted);
+}
+
+.onboarding-option:hover .onboarding-option__box {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 28px rgba(1, 61, 57, .12);
+}
+
+.onboarding-option input:focus-visible + .onboarding-option__box {
+  outline: 3px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.onboarding-option input:checked + .onboarding-option__box {
+  border-color: var(--gold);
+  box-shadow: 0 0 0 2px rgba(212, 175, 55, .35);
+  background: var(--bg-primary);
+}
+
+.onboarding-field {
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+}
+
+.onboarding-label {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.onboarding-input {
+  padding: .85rem 1rem;
+  font-size: 1rem;
+}
+
+.onboarding-hint {
+  margin: 0;
+  font-size: .85rem;
+  color: var(--text-muted);
+}
+
+.onboarding-actions {
+  margin-top: .5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: .75rem;
+}
+
+.onboarding-actions .btn {
+  min-width: 140px;
+}
+
+.onboarding-skip {
+  margin-top: 1.5rem;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: .9rem;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+}
+
+.onboarding-welcome {
+  margin-top: 1.5rem;
+  padding: 1rem 1.2rem;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  box-shadow: 0 16px 35px rgba(1, 61, 57, .08);
+  display: grid;
+  gap: .8rem;
+}
+
+.onboarding-welcome__message {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.onboarding-welcome__edit {
+  justify-self: start;
+  padding: .55rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(1, 61, 57, .25);
+  background: transparent;
+  color: var(--deep);
+  font-weight: 600;
+  font-size: .9rem;
+  cursor: pointer;
+  transition: background .2s ease, color .2s ease, border-color .2s ease;
+}
+
+.onboarding-welcome__edit:hover {
+  background: var(--gold);
+  color: var(--text-on-accent);
+  border-color: var(--gold);
+}
+
+[data-theme="dark"] .onboarding-dialog {
+  box-shadow: 0 32px 70px rgba(0, 0, 0, .55);
+}
+
+[data-theme="dark"] .onboarding-option__box {
+  border-color: rgba(212, 175, 55, .25);
+  background: rgba(26, 31, 30, .85);
+}
+
+[data-theme="dark"] .onboarding-option:hover .onboarding-option__box {
+  box-shadow: 0 20px 35px rgba(0, 0, 0, .45);
+}
+
+[data-theme="dark"] .onboarding-option input:checked + .onboarding-option__box {
+  background: rgba(10, 15, 14, .95);
+}
+
+[data-theme="dark"] .onboarding-welcome {
+  border-color: var(--border);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, .55);
+}
+
+[data-theme="dark"] .onboarding-welcome__edit {
+  border-color: rgba(212, 175, 55, .35);
+  color: var(--gold-2);
+}
+
+[data-theme="dark"] .onboarding-welcome__edit:hover {
+  background: var(--gold);
+  color: var(--text-on-accent);
+  border-color: var(--gold);
+}
+
+@media (max-width: 640px) {
+  .onboarding-dialog {
+    width: min(100%, 520px);
+    padding: 1.5rem;
+  }
+
+  .onboarding-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .onboarding-actions .btn {
+    width: 100%;
+  }
+
+  .onboarding-progress {
+    font-size: .7rem;
+  }
+}
+

--- a/index.html
+++ b/index.html
@@ -97,6 +97,87 @@
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5D39RVL3" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
   <a href="#main-content" class="skip-link">Lewati ke konten utama</a>
+  <div id="onboardingWizard" class="onboarding-overlay" hidden aria-hidden="true">
+    <div class="onboarding-overlay__backdrop" data-onboarding-close></div>
+    <div class="onboarding-dialog" role="dialog" aria-modal="true" aria-labelledby="onboardingTitle" data-onboarding-dialog>
+      <button type="button" class="onboarding-close" data-onboarding-close aria-label="Tutup wizard onboarding">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <span class="onboarding-progress" data-onboarding-progress>Langkah 1 dari 3</span>
+      <h2 id="onboardingTitle" class="onboarding-title">Selamat Datang di Sentral Emas</h2>
+      <p class="onboarding-summary" data-onboarding-summary>Pilih kebutuhan utama Anda agar rekomendasi lebih tepat.</p>
+      <form class="onboarding-form" data-onboarding-form novalidate>
+        <section class="onboarding-step" data-step="0">
+          <fieldset class="onboarding-fieldset">
+            <legend class="onboarding-legend">Apa yang ingin Anda jual?</legend>
+            <div class="onboarding-options">
+              <label class="onboarding-option">
+                <input type="radio" name="need" value="emas" />
+                <span class="onboarding-option__box">
+                  <span class="onboarding-option__title">Emas</span>
+                  <span class="onboarding-option__desc">Logam mulia & perhiasan emas</span>
+                </span>
+              </label>
+              <label class="onboarding-option">
+                <input type="radio" name="need" value="berlian" />
+                <span class="onboarding-option__box">
+                  <span class="onboarding-option__title">Berlian</span>
+                  <span class="onboarding-option__desc">Loose diamond atau berbalut perhiasan</span>
+                </span>
+              </label>
+              <label class="onboarding-option">
+                <input type="radio" name="need" value="jam" />
+                <span class="onboarding-option__box">
+                  <span class="onboarding-option__title">Jam Tangan Mewah</span>
+                  <span class="onboarding-option__desc">Rolex, Patek, AP, dan premium lainnya</span>
+                </span>
+              </label>
+            </div>
+          </fieldset>
+        </section>
+        <section class="onboarding-step" data-step="1" hidden>
+          <div class="onboarding-field">
+            <label class="onboarding-label" for="onboardingLocation">Di kota/area mana Anda berada?</label>
+            <input id="onboardingLocation" class="form-control onboarding-input" type="text" name="location" placeholder="Contoh: Jakarta Selatan" autocomplete="address-level2" />
+            <p class="onboarding-hint">Informasi lokasi membantu kami mengirim tim appraisal terdekat dan menyiapkan jadwal COD yang sesuai.</p>
+          </div>
+        </section>
+        <section class="onboarding-step" data-step="2" hidden>
+          <fieldset class="onboarding-fieldset">
+            <legend class="onboarding-legend">Kami perlu menghubungi Anda via?</legend>
+            <div class="onboarding-options">
+              <label class="onboarding-option">
+                <input type="radio" name="communication" value="whatsapp" />
+                <span class="onboarding-option__box">
+                  <span class="onboarding-option__title">WhatsApp</span>
+                  <span class="onboarding-option__desc">Respon tercepat & bisa kirim foto barang</span>
+                </span>
+              </label>
+              <label class="onboarding-option">
+                <input type="radio" name="communication" value="telepon" />
+                <span class="onboarding-option__box">
+                  <span class="onboarding-option__title">Telepon</span>
+                  <span class="onboarding-option__desc">Kami siap menjelaskan detail melalui panggilan</span>
+                </span>
+              </label>
+              <label class="onboarding-option">
+                <input type="radio" name="communication" value="email" />
+                <span class="onboarding-option__box">
+                  <span class="onboarding-option__title">Email</span>
+                  <span class="onboarding-option__desc">Lengkap dengan dokumentasi & rangkuman</span>
+                </span>
+              </label>
+            </div>
+          </fieldset>
+        </section>
+        <div class="onboarding-actions">
+          <button type="button" class="btn btn-ghost" data-onboarding-prev disabled>Sebelumnya</button>
+          <button type="button" class="btn btn-gold" data-onboarding-next disabled>Lanjut</button>
+        </div>
+      </form>
+      <button type="button" class="onboarding-skip" data-onboarding-close>Lewati untuk sekarang</button>
+    </div>
+  </div>
   <!-- ===================== NAVBAR ===================== -->
   <header>
     <div class="container nav">
@@ -215,6 +296,10 @@
             <span class="text-shimmer">Lebih Aman, Cepat, & Nyaman</span>
           </h1>
           <div class="typewriter" aria-live="polite"><span id="typer" class="text-rainbow"></span></div>
+          <div id="onboardingWelcome" class="onboarding-welcome" hidden>
+            <p class="onboarding-welcome__message" data-onboarding-message></p>
+            <button type="button" class="onboarding-welcome__edit" data-onboarding-edit>Ubah preferensi</button>
+          </div>
           <p class="lead">Di sini kami menerima jual dengan layanan buyback aman melalui <strong>COD se‑Jabodetabek & sekitarnya</strong>, mengikuti <strong>harga pasar pada hari transaksi</strong>. Terima: logam mulia; perhiasan emas (baru/lama, warisan/luar negeri, rusak/patah, bersurat/tanpa surat); berlian tanpa surat; jam tangan mewah; serta batu mulia (Safir, Rubi, Jamrud). Transparan, cepat, dan terpercaya.</p>
           <div class="btn-row mt-12">
             <a class="btn btn-gold" href="https://wa.me/6285591088503" target="_blank" rel="noopener noreferrer" data-track="wa-hero">WhatsApp Sekarang</a>


### PR DESCRIPTION
## Summary
- add a three-step onboarding wizard that guides first-time visitors through selecting kebutuhan, lokasi, and komunikasi preferences
- style the onboarding overlay and hero welcome banner so it matches the existing brand look and adapts to dark mode
- persist onboarding choices in localStorage and surface a personalized hero message with an edit shortcut for returning visitors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e091c4b1f08330806a23438fa33def