### PR TITLE
Enable screen reader access to sparkline canvas

### DIFF
--- a/harga/index.html
+++ b/harga/index.html
@@ -202,7 +202,7 @@
             <span class="price-highlight-unit">/gram</span>
           </div>
           <div class="price-highlight-chart">
-            <canvas id="lmBaruSparkline" height="60" aria-hidden="true" role="img" tabindex="0" aria-describedby="lmBaruTrendSummary lmBaruSparklinePointSummary"></canvas>
+            <canvas id="lmBaruSparkline" height="60" role="img" tabindex="0" aria-describedby="lmBaruTrendSummary lmBaruSparklinePointSummary"></canvas>
             <div id="lmBaruSparklineMarker" class="sparkline-marker" aria-hidden="true"></div>
             <div id="lmBaruSparklineTooltip" class="sparkline-tooltip" role="tooltip" aria-hidden="true"></div>
             <div id="lmBaruChartFallback" class="chart-fallback is-visible" role="note">Grafik menunggu data riwayat harga.</div>

--- a/index.html
+++ b/index.html
@@ -275,7 +275,7 @@
             <span class="price-highlight-unit">/gram</span>
           </div>
           <div class="price-highlight-chart">
-            <canvas id="lmBaruSparkline" height="60" aria-hidden="true" role="img" tabindex="0" aria-describedby="lmBaruTrendSummary lmBaruSparklinePointSummary"></canvas>
+            <canvas id="lmBaruSparkline" height="60" role="img" tabindex="0" aria-describedby="lmBaruTrendSummary lmBaruSparklinePointSummary"></canvas>
             <div id="lmBaruSparklineMarker" class="sparkline-marker" aria-hidden="true"></div>
             <div id="lmBaruSparklineTooltip" class="sparkline-tooltip" role="tooltip" aria-hidden="true"></div>
             <div id="lmBaruChartFallback" class="chart-fallback is-visible" role="note">Grafik menunggu data riwayat harga.</div>


### PR DESCRIPTION
## Summary
- remove the aria-hidden attribute from the sparkline canvas so screen readers can follow its described summary

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e149b2f040833096a84bfd0f3801d2