### PR TITLE
feat: remember sub-24k selection

### DIFF
--- a/harga/index.html
+++ b/harga/index.html
@@ -284,7 +284,7 @@
             <div class="calc-field">
               <label for="cal-kadar" class="h3">Kadar</label>
               <select id="cal-kadar" class="form-control converter-select">
-                <option value="24">24K</option>
+                <option value="24" data-hide-when-sub="true">24K</option>
                 <option value="23">23K</option>
                 <option value="22">22K</option>
                 <option value="21">21K</option>


### PR DESCRIPTION
## Summary
- persist the last sub-24K purity selection and restore it when the category is reactivated
- clamp purity values for <24K items, update UI state, and hide the 24K option while the sub-24K category is active
- ensure the calculator preview, item list, and WhatsApp message all consume the sanitized purity values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e14ec2616c8330862ae4eb92b66e4f