### PR TITLE
Add manifest links to standalone pages

### DIFF
--- a/blog/checklist-foto-emas-cod/index.html
+++ b/blog/checklist-foto-emas-cod/index.html
@@ -36,6 +36,7 @@
   <meta name="twitter:description" content="Lengkapi permintaan buyback Sentral Emas dengan foto dan dokumen yang tepat agar estimasi COD lebih cepat dan akurat." />
   <meta name="twitter:image" content="https://sentralemas.com/assets/img/asset9.webp" />
   <meta name="twitter:image:alt" content="Ilustrasi pengecekan perhiasan emas" />
+  <link rel="manifest" href="/manifest.webmanifest" />
   <link rel="stylesheet" href="/assets/css/fonts.css" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
   <link rel="icon" href="/assets/icons/favicon.ico" sizes="32x32" type="image/x-icon" />

--- a/blog/index.html
+++ b/blog/index.html
@@ -32,6 +32,7 @@
   <meta name="twitter:description" content="Artikel dan panduan Sentral Emas seputar tips jual beli emas & berlian via COD yang aman dan transparan." />
   <meta name="twitter:image" content="https://sentralemas.com/assets/icons/android-chrome-512x512.png" />
   <meta name="twitter:image:alt" content="Logo Sentral Emas" />
+  <link rel="manifest" href="/manifest.webmanifest" />
   <link rel="stylesheet" href="/assets/css/fonts.css" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
   <link rel="icon" href="/assets/icons/favicon.ico" sizes="32x32" type="image/x-icon" />

--- a/blog/keuntungan-jual-emas-cod/index.html
+++ b/blog/keuntungan-jual-emas-cod/index.html
@@ -36,6 +36,7 @@
   <meta name="twitter:description" content="Pelajari keuntungan menggunakan layanan buyback emas COD Sentral Emas beserta tips menyiapkan transaksi agar proses aman dan transparan." />
   <meta name="twitter:image" content="https://sentralemas.com/assets/img/asset10.webp" />
   <meta name="twitter:image:alt" content="Ilustrasi buyback emas Sentral Emas" />
+  <link rel="manifest" href="/manifest.webmanifest" />
   <link rel="stylesheet" href="/assets/css/fonts.css" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
   <link rel="icon" href="/assets/icons/favicon.ico" sizes="32x32" type="image/x-icon" />

--- a/blog/panduan-buyback-berlian/index.html
+++ b/blog/panduan-buyback-berlian/index.html
@@ -48,6 +48,7 @@
   <meta name="twitter:image:alt" content="Pahami 4C (Cut, Color, Clarity, Carat)" />
   <link rel="alternate" href="https://sentralemas.com/blog/panduan-buyback-berlian/" hreflang="id-ID" />
   <link rel="alternate" href="https://sentralemas.com/blog/panduan-buyback-berlian/" hreflang="x-default" />
+  <link rel="manifest" href="/manifest.webmanifest" />
   <link rel="preload" href="/assets/css/styles.css" as="style">
   <link rel="preload" href="/assets/css/fonts.css" as="style">
   <link rel="stylesheet" href="/assets/css/fonts.css">

--- a/blog/panduan-jual-emas-tanpa-surat/index.html
+++ b/blog/panduan-jual-emas-tanpa-surat/index.html
@@ -36,6 +36,7 @@
   <meta name="twitter:description" content="Pelajari langkah aman jual emas tanpa surat resmi, termasuk cara verifikasi, mitigasi risiko, dan solusi COD." />
   <meta name="twitter:image" content="https://sentralemas.com/assets/img/asset7.webp" />
   <meta name="twitter:image:alt" content="Panduan jual emas tanpa surat Sentral Emas" />
+  <link rel="manifest" href="/manifest.webmanifest" />
   <link rel="stylesheet" href="/assets/css/fonts.css" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
   <link rel="icon" href="/assets/icons/favicon.ico" sizes="32x32" type="image/x-icon" />

--- a/blog/panduan-menilai-keaslian-emas-sebelum-cod/index.html
+++ b/blog/panduan-menilai-keaslian-emas-sebelum-cod/index.html
@@ -36,6 +36,7 @@
   <meta name="twitter:description" content="Langkah praktis memeriksa keaslian emas di rumah sebelum transaksi COD dengan Sentral Emas." />
   <meta name="twitter:image" content="https://sentralemas.com/assets/img/asset11.webp" />
   <meta name="twitter:image:alt" content="Panduan cek emas Sentral Emas" />
+  <link rel="manifest" href="/manifest.webmanifest" />
   <link rel="stylesheet" href="/assets/css/fonts.css" />
   <link rel="stylesheet" href="/assets/css/styles.css" />
   <link rel="icon" href="/assets/icons/favicon.ico" sizes="32x32" type="image/x-icon" />

--- a/harga/index.html
+++ b/harga/index.html
@@ -44,6 +44,7 @@
   <meta name="twitter:image:alt" content="Simulasi harga buyback emas Sentral Emas" />
   <link rel="alternate" href="https://sentralemas.com/harga/" hreflang="x-default" />
   <link rel="alternate" href="https://sentralemas.com/harga/" hreflang="id-ID" />
+  <link rel="manifest" href="/manifest.webmanifest" />
   <link rel="preload" href="/assets/css/styles.css" as="style">
   <link rel="preload" href="/assets/css/fonts.css" as="style">
   <link rel="stylesheet" href="/assets/css/fonts.css">

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
   <link rel="dns-prefetch" href="https://www.googletagmanager.com">
   <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
   <!-- PWA: manifest & app capability -->
-  <link rel="manifest" href="./manifest.webmanifest">
+  <link rel="manifest" href="/manifest.webmanifest">
 
   <link rel="icon" href="assets/icons/favicon.ico" sizes="32x32" type="image/x-icon" />
   <link rel="shortcut icon" href="assets/icons/favicon.ico" type="image/x-icon" />

--- a/offline.html
+++ b/offline.html
@@ -22,6 +22,7 @@
   <meta name="twitter:title" content="Offline • Sentral Emas">
   <meta name="twitter:description" content="Anda sedang offline. Muat ulang situs Sentral Emas setelah kembali terhubung.">
   <meta name="twitter:image" content="https://sentralemas.com/assets/icons/android-chrome-512x512.png">
+  <link rel="manifest" href="/manifest.webmanifest">
   <style>
     :root {
       --offline-gold: #D4AF37;


### PR DESCRIPTION
## Summary
- add the web app manifest link to the harga page and every blog article so installability works from subdirectories
- switch the homepage manifest reference to an absolute path and include the manifest on the offline template for consistent PWA metadata

## Testing
- npx --yes lighthouse http://127.0.0.1:4173/ --only-categories=pwa --chrome-flags="--headless --no-sandbox" *(fails: npm 403 when downloading Lighthouse)*

------
https://chatgpt.com/codex/tasks/task_e_68e15127c81c8330a19567a54b4559c6