### PR TITLE
Restyle global gold spot card to match price highlight

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2084,150 +2084,154 @@ tbody tr:hover td {
   margin: 0 auto
 }
 
-/* --- World spot price card & table --- */
-.world-price-card {
-  padding: 1.4rem 1.6rem;
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow);
+/* --- World spot price highlight --- */
+.world-price-highlight {
+  max-width: 760px;
+  margin: 1.6rem auto 0;
+  padding: 1.6rem;
+  gap: 1.2rem;
+}
+
+.world-price-highlight .world-price-content {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  margin: 1.6rem auto 0;
-  container-type: inline-size;
-  container-name: world-price-card;
+  gap: 1.1rem;
 }
 
-.world-price-card__head {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 1.2rem;
-  flex-wrap: wrap;
-  row-gap: .4rem;
+.world-price-highlight .price-highlight-headline {
+  gap: .45rem;
 }
 
-.world-price-card__head .accent-title {
-  margin-bottom: .25rem;
-  letter-spacing: .12em;
-}
-
-.world-price-card .h3 {
+.world-price-highlight .price-highlight-title {
   margin: 0;
-  font-size: 1.2rem;
-  color: var(--deep);
-}
-
-.world-price-card .date-badge {
-  white-space: nowrap;
-}
-
-.world-price-card__body {
-  display: grid;
-  grid-template-columns: minmax(0, auto) minmax(0, 1fr);
-  grid-template-areas: "value note";
-  align-items: start;
-  gap: .6rem 1.4rem;
-}
-
-.world-price-value {
-  grid-area: value;
-  font-size: clamp(1.8rem, 2.3vw + 1rem, 2.7rem);
+  font-size: clamp(1.2rem, .7vw + 1.05rem, 1.45rem);
   font-weight: 700;
-  color: var(--deep);
+  color: #fff;
   letter-spacing: -.01em;
 }
 
-.world-price-card .text-note {
-  grid-area: note;
-  margin: 0;
-  color: var(--muted);
+.world-price-highlight .price-highlight-main {
+  align-items: flex-end;
+  gap: .5rem;
 }
 
-@container world-price-card (max-width: 520px) {
-  .world-price-card__body {
-    grid-template-columns: 1fr;
-    grid-template-areas:
-      "value"
-      "note";
-    gap: .5rem;
-  }
+.world-price-highlight .price-highlight-value {
+  font-size: clamp(2rem, 2.2vw + 1.2rem, 2.85rem);
+  font-weight: 700;
+  color: #fff;
 }
 
-#globalGoldPriceTableCard {
-  max-width: 720px;
-  margin: 1.6rem auto 0;
-  overflow: hidden;
-}
-
-#globalGoldPriceTableCard .table-card__head {
-  padding: 1.4rem 1.6rem .8rem;
-  border-bottom: 1px solid var(--border);
-  display: grid;
-  gap: .25rem;
-}
-
-#globalGoldPriceTableCard .table-card__head .h3 {
-  margin: 0;
-}
-
-#globalGoldPriceTableCard .table-card__head .text-note {
-  margin: 0;
-  color: var(--muted);
-}
-
-.world-price-table thead th:first-child {
-  border-top-left-radius: 0;
-}
-
-.world-price-table thead th:last-child {
-  border-top-right-radius: 0;
-}
-
-.world-price-table tbody td:first-child {
+.world-price-highlight .price-highlight-unit {
+  font-size: 1.05rem;
   font-weight: 600;
-  color: var(--deep);
+  color: rgba(224, 248, 244, .82);
 }
 
-.world-price-table tbody td:last-child {
+.world-price-highlight .price-highlight-note,
+.world-price-highlight .text-note {
+  margin: 0;
+  color: rgba(224, 248, 244, .74);
+}
+
+.world-price-highlight .date-badge {
+  background: rgba(255, 255, 255, .16);
+  color: #fff;
+}
+
+.world-price-highlight .world-price-breakdown {
+  border-radius: calc(var(--radius) - 4px);
+  background: linear-gradient(180deg, rgba(255, 255, 255, .08), rgba(255, 255, 255, .02));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, .06);
+  padding: 1rem 1.25rem 1.1rem;
+}
+
+.world-price-highlight .world-price-table {
+  width: 100%;
+  border-collapse: collapse;
+  color: rgba(239, 255, 252, .92);
+  font-size: .96rem;
+}
+
+.world-price-highlight .world-price-table thead th {
+  padding: .45rem 0 .65rem;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  font-size: .75rem;
+  font-weight: 600;
+  color: rgba(224, 248, 244, .7);
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, .12);
+}
+
+.world-price-highlight .world-price-table thead th:last-child {
+  text-align: right;
+}
+
+.world-price-highlight .world-price-table tbody td {
+  padding: .65rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, .08);
+}
+
+.world-price-highlight .world-price-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.world-price-highlight .world-price-table tbody td:first-child {
+  font-weight: 600;
+  color: rgba(255, 255, 255, .9);
+}
+
+.world-price-highlight .world-price-table tbody td:last-child {
   text-align: right;
   font-variant-numeric: tabular-nums;
   font-weight: 600;
+  color: rgba(255, 255, 255, .95);
+}
+
+.world-price-highlight .world-price-table .text-note {
+  text-align: center;
+  padding: .75rem 0;
+}
+
+#globalGoldPriceCard .skeleton-content {
+  display: none;
+}
+
+#globalGoldPriceCard[aria-busy="true"] .skeleton-content {
+  display: block;
+}
+
+#globalGoldPriceCard[aria-busy="true"] .world-price-content {
+  display: none;
 }
 
 @media (max-width: 860px) {
-  .world-price-card {
-    padding: 1.3rem 1.4rem;
-    gap: .85rem;
+  .world-price-highlight {
+    padding: 1.4rem 1.45rem;
+    gap: 1rem;
   }
 
-  .world-price-card__head {
-    gap: .9rem;
-  }
-
-  .world-price-value {
-    font-size: clamp(1.65rem, 2.1vw + 1rem, 2.5rem);
+  .world-price-highlight .world-price-breakdown {
+    padding: .9rem 1.05rem 1rem;
   }
 }
 
 @media (max-width: 720px) {
-  .world-price-card {
-    padding: 1.2rem 1.25rem;
-    gap: .75rem;
+  .world-price-highlight {
+    padding: 1.3rem 1.25rem;
+    gap: .95rem;
   }
 
-  .world-price-card__head {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: .6rem;
+  .world-price-highlight .price-highlight-title {
+    font-size: clamp(1.1rem, 1.2rem, 1.3rem);
   }
 
-  .world-price-card .date-badge {
-    font-size: .9rem;
+  .world-price-highlight .world-price-breakdown {
+    padding: .85rem 1rem .95rem;
   }
 
-  #globalGoldPriceTableCard {
-    margin-top: 1.4rem;
+  .world-price-highlight .world-price-table {
+    font-size: .92rem;
   }
 }
 

--- a/harga/index.html
+++ b/harga/index.html
@@ -354,38 +354,39 @@
       <div class="container">
         <div class="accent-title">Referensi Global</div>
         <h2 class="h2">Harga Emas Spot Dunia (XAU)</h2>
-        <div id="globalGoldPriceCard" class="card world-price-card mt-12" role="status" aria-live="polite" aria-busy="true">
-          <div class="world-price-card__head">
-            <div>
-              <h3 class="h3">Nilai Murni Emas Global</h3>
+        <div id="globalGoldPriceCard" class="card price-highlight world-price-highlight mt-12" role="status" aria-live="polite" aria-busy="true">
+          <div class="skeleton-content" aria-hidden="true">
+            <div class="skeleton skeleton-line" style="width: 200px; height: 1.1rem;"></div>
+            <div class="skeleton skeleton-price" style="height: 2.6rem; width: 220px; margin-top: .6rem;"></div>
+            <div class="skeleton skeleton-line" style="width: 60%; height: 1rem; margin-top: .8rem;"></div>
+            <div class="skeleton skeleton-line" style="width: 100%; height: 52px; margin-top: .9rem;"></div>
+          </div>
+          <div class="world-price-content">
+            <div class="price-highlight-head">
+              <div class="price-highlight-headline">
+                <p class="price-highlight-label">Nilai Murni Emas Global</p>
+                <h3 class="price-highlight-title">Harga Spot Dunia</h3>
+              </div>
+              <span id="globalGoldPriceDate" class="date-badge">—</span>
             </div>
-            <span id="globalGoldPriceDate" class="date-badge">—</span>
+            <div class="price-highlight-main">
+              <span id="globalGoldPricePerGram" class="price-highlight-value">Rp —</span>
+              <span class="price-highlight-unit">/gram</span>
+            </div>
+            <p class="price-highlight-note text-note" id="globalGoldPriceNote">Harga per gram dalam Rupiah (kurs <span class="nowrap">XAU/IDR</span>).</p>
+            <div class="world-price-breakdown">
+              <table class="world-price-table" aria-label="Tabel harga emas dunia">
+                <thead>
+                  <tr>
+                    <th scope="col">Satuan</th>
+                    <th scope="col">Harga (Rp)</th>
+                  </tr>
+                </thead>
+                <tbody id="globalGoldPriceTable" aria-live="polite" aria-busy="true"></tbody>
+              </table>
+            </div>
+            <p class="price-highlight-note text-note" id="globalGoldPriceTableNote">Ini adalah harga murni sebagai acuan global, belum termasuk biaya admin atau penyesuaian lainnya.</p>
           </div>
-          <div class="world-price-card__body">
-            <div class="world-price-value" id="globalGoldPricePerGram">Rp —</div>
-            <p class="text-note" id="globalGoldPriceNote">Harga per gram dalam Rupiah (kurs <span class="nowrap">XAU/IDR</span>).</p>
-          </div>
-          <div class="table-wrap">
-            <table class="world-price-table" aria-label="Tabel harga emas dunia">
-              <thead>
-                <tr>
-                  <th>Satuan</th>
-                  <th>Harga (Rp)</th>
-                </tr>
-              </thead>
-              <tbody id="globalGoldPriceTable" aria-live="polite" aria-busy="true">
-                <tr class="skeleton-row" aria-hidden="true">
-                  <td>
-                    <div class="skeleton skeleton-line" style="width: 90px;"></div>
-                  </td>
-                  <td align="right">
-                    <div class="skeleton skeleton-price"></div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <p class="text-note" id="globalGoldPriceTableNote" style="padding: 0 2rem 2rem">Ini adalah harga murni sebagai acuan global, belum termasuk biaya admin atau penyesuaian lainnya.</p>
         </div>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -489,38 +489,39 @@
       <div class="container">
         <div class="accent-title">Referensi Global</div>
         <h2 class="h2">Harga Emas Spot Dunia (XAU)</h2>
-        <div id="globalGoldPriceCard" class="card world-price-card mt-12" role="status" aria-live="polite" aria-busy="true">
-          <div class="world-price-card__head">
-            <div>
-              <h3 class="h3">Nilai Murni Emas Global</h3>
+        <div id="globalGoldPriceCard" class="card price-highlight world-price-highlight mt-12" role="status" aria-live="polite" aria-busy="true">
+          <div class="skeleton-content" aria-hidden="true">
+            <div class="skeleton skeleton-line" style="width: 200px; height: 1.1rem;"></div>
+            <div class="skeleton skeleton-price" style="height: 2.6rem; width: 220px; margin-top: .6rem;"></div>
+            <div class="skeleton skeleton-line" style="width: 60%; height: 1rem; margin-top: .8rem;"></div>
+            <div class="skeleton skeleton-line" style="width: 100%; height: 52px; margin-top: .9rem;"></div>
+          </div>
+          <div class="world-price-content">
+            <div class="price-highlight-head">
+              <div class="price-highlight-headline">
+                <p class="price-highlight-label">Nilai Murni Emas Global</p>
+                <h3 class="price-highlight-title">Harga Spot Dunia</h3>
+              </div>
+              <span id="globalGoldPriceDate" class="date-badge">—</span>
             </div>
-            <span id="globalGoldPriceDate" class="date-badge">—</span>
+            <div class="price-highlight-main">
+              <span id="globalGoldPricePerGram" class="price-highlight-value">Rp —</span>
+              <span class="price-highlight-unit">/gram</span>
+            </div>
+            <p class="price-highlight-note text-note" id="globalGoldPriceNote">Harga per gram dalam Rupiah (kurs <span class="nowrap">XAU/IDR</span>).</p>
+            <div class="world-price-breakdown">
+              <table class="world-price-table" aria-label="Tabel harga emas dunia">
+                <thead>
+                  <tr>
+                    <th scope="col">Satuan</th>
+                    <th scope="col">Harga (Rp)</th>
+                  </tr>
+                </thead>
+                <tbody id="globalGoldPriceTable" aria-live="polite" aria-busy="true"></tbody>
+              </table>
+            </div>
+            <p class="price-highlight-note text-note" id="globalGoldPriceTableNote">Ini adalah harga murni sebagai acuan global, belum termasuk biaya admin atau penyesuaian lainnya.</p>
           </div>
-          <div class="world-price-card__body">
-            <div class="world-price-value" id="globalGoldPricePerGram">Rp —</div>
-            <p class="text-note" id="globalGoldPriceNote">Harga per gram dalam Rupiah (kurs <span class="nowrap">XAU/IDR</span>).</p>
-          </div>
-          <div class="table-wrap">
-            <table class="world-price-table" aria-label="Tabel harga emas dunia">
-              <thead>
-                <tr>
-                  <th>Satuan</th>
-                  <th>Harga (Rp)</th>
-                </tr>
-              </thead>
-              <tbody id="globalGoldPriceTable" aria-live="polite" aria-busy="true">
-                <tr class="skeleton-row" aria-hidden="true">
-                  <td>
-                    <div class="skeleton skeleton-line" style="width: 90px;"></div>
-                  </td>
-                  <td align="right">
-                    <div class="skeleton skeleton-price"></div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <p class="text-note" id="globalGoldPriceTableNote" style="padding: 0 2rem 2rem">Ini adalah harga murni sebagai acuan global, belum termasuk biaya admin atau penyesuaian lainnya.</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- restyle the "Harga Emas Spot Dunia" widget so it reuses the price highlight layout and skeleton loader
- align the dedicated harga page markup with the new card structure
- add new world price highlight styling for notes, table, and responsive behaviour

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e15d9265348330b78e10d2a31cc991