### PR TITLE
Match world spot gold card styling with daily highlight

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2084,150 +2084,161 @@ tbody tr:hover td {
   margin: 0 auto
 }
 
-/* --- World spot price card & table --- */
-.world-price-card {
-  padding: 1.4rem 1.6rem;
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow);
+/* --- World spot price highlight --- */
+.price-highlight.world-price-card {
+  margin: 1.6rem auto 0;
+  padding: 1.6rem;
+  gap: 1.2rem;
+}
+
+.price-highlight.world-price-card .price-highlight-headline {
+  gap: .3rem;
+}
+
+.price-highlight.world-price-card .price-highlight-label {
+  letter-spacing: .14em;
+}
+
+.price-highlight.world-price-card .h3 {
+  margin: 0;
+  font-size: clamp(1.2rem, 1.6vw + .8rem, 1.6rem);
+  font-weight: 700;
+}
+
+.price-highlight.world-price-card .price-highlight-controls {
+  gap: .5rem;
+}
+
+.price-highlight.world-price-card .price-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: .35rem .8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(239, 255, 252, .3);
+  background: rgba(239, 255, 252, .12);
+  color: rgba(239, 255, 252, .92);
+  font-weight: 600;
+  letter-spacing: .04em;
+}
+
+.price-highlight-note {
+  margin: 0;
+  font-size: .96rem;
+  line-height: 1.5;
+  color: rgba(239, 255, 252, .78);
+}
+
+.world-price-content {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  margin: 1.6rem auto 0;
-  container-type: inline-size;
-  container-name: world-price-card;
+  gap: 1.1rem;
 }
 
-.world-price-card__head {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 1.2rem;
-  flex-wrap: wrap;
-  row-gap: .4rem;
-}
-
-.world-price-card__head .accent-title {
-  margin-bottom: .25rem;
-  letter-spacing: .12em;
-}
-
-.world-price-card .h3 {
-  margin: 0;
-  font-size: 1.2rem;
-  color: var(--deep);
-}
-
-.world-price-card .date-badge {
-  white-space: nowrap;
-}
-
-.world-price-card__body {
-  display: grid;
-  grid-template-columns: minmax(0, auto) minmax(0, 1fr);
-  grid-template-areas: "value note";
-  align-items: start;
-  gap: .6rem 1.4rem;
-}
-
-.world-price-value {
-  grid-area: value;
-  font-size: clamp(1.8rem, 2.3vw + 1rem, 2.7rem);
-  font-weight: 700;
-  color: var(--deep);
-  letter-spacing: -.01em;
-}
-
-.world-price-card .text-note {
-  grid-area: note;
-  margin: 0;
-  color: var(--muted);
-}
-
-@container world-price-card (max-width: 520px) {
-  .world-price-card__body {
-    grid-template-columns: 1fr;
-    grid-template-areas:
-      "value"
-      "note";
-    gap: .5rem;
-  }
-}
-
-#globalGoldPriceTableCard {
-  max-width: 720px;
-  margin: 1.6rem auto 0;
+.world-price-table-wrap {
+  border-radius: calc(var(--radius) - .3rem);
+  border: 1px solid rgba(239, 255, 252, .18);
+  background: rgba(1, 61, 57, .32);
   overflow: hidden;
 }
 
-#globalGoldPriceTableCard .table-card__head {
-  padding: 1.4rem 1.6rem .8rem;
-  border-bottom: 1px solid var(--border);
-  display: grid;
-  gap: .25rem;
+.world-price-table {
+  width: 100%;
+  border-collapse: collapse;
+  color: inherit;
 }
 
-#globalGoldPriceTableCard .table-card__head .h3 {
-  margin: 0;
+.world-price-table thead {
+  background: rgba(239, 255, 252, .08);
 }
 
-#globalGoldPriceTableCard .table-card__head .text-note {
-  margin: 0;
-  color: var(--muted);
-}
-
-.world-price-table thead th:first-child {
-  border-top-left-radius: 0;
+.world-price-table thead th {
+  padding: .8rem 1rem;
+  text-align: left;
+  font-size: .78rem;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: rgba(239, 255, 252, .78);
+  border-bottom: 1px solid rgba(239, 255, 252, .14);
 }
 
 .world-price-table thead th:last-child {
-  border-top-right-radius: 0;
+  text-align: right;
+}
+
+.world-price-table tbody td {
+  padding: .85rem 1rem;
+  border-bottom: 1px solid rgba(239, 255, 252, .12);
+  font-size: .97rem;
+  color: rgba(239, 255, 252, .9);
 }
 
 .world-price-table tbody td:first-child {
   font-weight: 600;
-  color: var(--deep);
 }
 
 .world-price-table tbody td:last-child {
   text-align: right;
   font-variant-numeric: tabular-nums;
-  font-weight: 600;
+  font-weight: 700;
+}
+
+.world-price-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.world-price-table tbody td.text-note {
+  text-align: center;
+  font-weight: 500;
+}
+
+#globalGoldPriceCard .skeleton-content {
+  display: none;
+  flex-direction: column;
+  gap: .75rem;
+}
+
+#globalGoldPriceCard[aria-busy="true"] .skeleton-content {
+  display: flex;
+}
+
+#globalGoldPriceCard[aria-busy="true"] .world-price-content {
+  visibility: hidden;
+}
+
+#globalGoldPriceCard[data-state="error"] .price-badge {
+  border-color: rgba(255, 97, 97, .42);
+  background: rgba(255, 97, 97, .18);
+  color: rgba(255, 233, 233, .94);
+}
+
+#globalGoldPriceCard[data-state="error"] .world-price-table tbody td {
+  color: rgba(239, 255, 252, .78);
 }
 
 @media (max-width: 860px) {
-  .world-price-card {
-    padding: 1.3rem 1.4rem;
-    gap: .85rem;
+  .price-highlight.world-price-card {
+    padding: 1.4rem;
+    gap: 1rem;
   }
 
-  .world-price-card__head {
-    gap: .9rem;
-  }
-
-  .world-price-value {
-    font-size: clamp(1.65rem, 2.1vw + 1rem, 2.5rem);
+  .world-price-table tbody td {
+    padding: .75rem .9rem;
   }
 }
 
 @media (max-width: 720px) {
-  .world-price-card {
-    padding: 1.2rem 1.25rem;
-    gap: .75rem;
+  .price-highlight.world-price-card {
+    padding: 1.25rem;
   }
 
-  .world-price-card__head {
-    flex-direction: column;
-    align-items: flex-start;
+  .price-highlight.world-price-card .price-highlight-head {
     gap: .6rem;
   }
 
-  .world-price-card .date-badge {
-    font-size: .9rem;
-  }
-
-  #globalGoldPriceTableCard {
-    margin-top: 1.4rem;
+  .world-price-table thead th,
+  .world-price-table tbody td {
+    padding-inline: .75rem;
   }
 }
 

--- a/harga/index.html
+++ b/harga/index.html
@@ -354,38 +354,53 @@
       <div class="container">
         <div class="accent-title">Referensi Global</div>
         <h2 class="h2">Harga Emas Spot Dunia (XAU)</h2>
-        <div id="globalGoldPriceCard" class="card world-price-card mt-12" role="status" aria-live="polite" aria-busy="true">
-          <div class="world-price-card__head">
-            <div>
-              <h3 class="h3">Nilai Murni Emas Global</h3>
+        <div id="globalGoldPriceCard" class="card price-highlight world-price-card mt-12" role="status" aria-live="polite" aria-busy="true">
+          <div class="skeleton-content" aria-hidden="true">
+            <div class="flex-split">
+              <div class="skeleton skeleton-line" style="width: 160px; height: 1.1rem;"></div>
+              <div class="skeleton skeleton-badge"></div>
             </div>
-            <span id="globalGoldPriceDate" class="date-badge">—</span>
+            <div class="skeleton skeleton-price" style="height: 2.4rem; width: 220px;"></div>
+            <div class="skeleton skeleton-delta" style="width: 240px;"></div>
+            <div class="skeleton skeleton-line" style="width: 100%; height: 52px; margin-top: .4rem;"></div>
           </div>
-          <div class="world-price-card__body">
-            <div class="world-price-value" id="globalGoldPricePerGram">Rp —</div>
-            <p class="text-note" id="globalGoldPriceNote">Harga per gram dalam Rupiah (kurs <span class="nowrap">XAU/IDR</span>).</p>
+          <div class="world-price-content">
+            <div class="price-highlight-head">
+              <div class="price-highlight-headline">
+                <p class="price-highlight-label">Update Spot Dunia</p>
+                <h3 class="h3">Nilai Murni Emas Global</h3>
+              </div>
+              <div class="price-highlight-controls">
+                <span id="globalGoldPriceDate" class="price-badge price-neutral">Menunggu</span>
+              </div>
+            </div>
+            <div class="price-highlight-main">
+              <span id="globalGoldPricePerGram" class="price-highlight-value">Rp —</span>
+              <span class="price-highlight-unit">/gram</span>
+            </div>
+            <p class="price-highlight-note" id="globalGoldPriceNote">Harga per gram dalam Rupiah (kurs <span class="nowrap">XAU/IDR</span>).</p>
+            <div class="world-price-table-wrap table-wrap">
+              <table class="world-price-table" aria-label="Tabel harga emas dunia">
+                <thead>
+                  <tr>
+                    <th scope="col">Satuan</th>
+                    <th scope="col">Harga (Rp)</th>
+                  </tr>
+                </thead>
+                <tbody id="globalGoldPriceTable" aria-live="polite" aria-busy="true">
+                  <tr class="skeleton-row" aria-hidden="true">
+                    <td>
+                      <div class="skeleton skeleton-line" style="width: 110px;"></div>
+                    </td>
+                    <td align="right">
+                      <div class="skeleton skeleton-price" style="width: 140px;"></div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p class="price-highlight-note" id="globalGoldPriceTableNote">Ini adalah harga murni sebagai acuan global, belum termasuk biaya admin atau penyesuaian lainnya.</p>
           </div>
-          <div class="table-wrap">
-            <table class="world-price-table" aria-label="Tabel harga emas dunia">
-              <thead>
-                <tr>
-                  <th>Satuan</th>
-                  <th>Harga (Rp)</th>
-                </tr>
-              </thead>
-              <tbody id="globalGoldPriceTable" aria-live="polite" aria-busy="true">
-                <tr class="skeleton-row" aria-hidden="true">
-                  <td>
-                    <div class="skeleton skeleton-line" style="width: 90px;"></div>
-                  </td>
-                  <td align="right">
-                    <div class="skeleton skeleton-price"></div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <p class="text-note" id="globalGoldPriceTableNote" style="padding: 0 2rem 2rem">Ini adalah harga murni sebagai acuan global, belum termasuk biaya admin atau penyesuaian lainnya.</p>
         </div>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -489,38 +489,53 @@
       <div class="container">
         <div class="accent-title">Referensi Global</div>
         <h2 class="h2">Harga Emas Spot Dunia (XAU)</h2>
-        <div id="globalGoldPriceCard" class="card world-price-card mt-12" role="status" aria-live="polite" aria-busy="true">
-          <div class="world-price-card__head">
-            <div>
-              <h3 class="h3">Nilai Murni Emas Global</h3>
+        <div id="globalGoldPriceCard" class="card price-highlight world-price-card mt-12" role="status" aria-live="polite" aria-busy="true">
+          <div class="skeleton-content" aria-hidden="true">
+            <div class="flex-split">
+              <div class="skeleton skeleton-line" style="width: 160px; height: 1.1rem;"></div>
+              <div class="skeleton skeleton-badge"></div>
             </div>
-            <span id="globalGoldPriceDate" class="date-badge">—</span>
+            <div class="skeleton skeleton-price" style="height: 2.4rem; width: 220px;"></div>
+            <div class="skeleton skeleton-delta" style="width: 240px;"></div>
+            <div class="skeleton skeleton-line" style="width: 100%; height: 52px; margin-top: .4rem;"></div>
           </div>
-          <div class="world-price-card__body">
-            <div class="world-price-value" id="globalGoldPricePerGram">Rp —</div>
-            <p class="text-note" id="globalGoldPriceNote">Harga per gram dalam Rupiah (kurs <span class="nowrap">XAU/IDR</span>).</p>
+          <div class="world-price-content">
+            <div class="price-highlight-head">
+              <div class="price-highlight-headline">
+                <p class="price-highlight-label">Update Spot Dunia</p>
+                <h3 class="h3">Nilai Murni Emas Global</h3>
+              </div>
+              <div class="price-highlight-controls">
+                <span id="globalGoldPriceDate" class="price-badge price-neutral">Menunggu</span>
+              </div>
+            </div>
+            <div class="price-highlight-main">
+              <span id="globalGoldPricePerGram" class="price-highlight-value">Rp —</span>
+              <span class="price-highlight-unit">/gram</span>
+            </div>
+            <p class="price-highlight-note" id="globalGoldPriceNote">Harga per gram dalam Rupiah (kurs <span class="nowrap">XAU/IDR</span>).</p>
+            <div class="world-price-table-wrap table-wrap">
+              <table class="world-price-table" aria-label="Tabel harga emas dunia">
+                <thead>
+                  <tr>
+                    <th scope="col">Satuan</th>
+                    <th scope="col">Harga (Rp)</th>
+                  </tr>
+                </thead>
+                <tbody id="globalGoldPriceTable" aria-live="polite" aria-busy="true">
+                  <tr class="skeleton-row" aria-hidden="true">
+                    <td>
+                      <div class="skeleton skeleton-line" style="width: 110px;"></div>
+                    </td>
+                    <td align="right">
+                      <div class="skeleton skeleton-price" style="width: 140px;"></div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p class="price-highlight-note" id="globalGoldPriceTableNote">Ini adalah harga murni sebagai acuan global, belum termasuk biaya admin atau penyesuaian lainnya.</p>
           </div>
-          <div class="table-wrap">
-            <table class="world-price-table" aria-label="Tabel harga emas dunia">
-              <thead>
-                <tr>
-                  <th>Satuan</th>
-                  <th>Harga (Rp)</th>
-                </tr>
-              </thead>
-              <tbody id="globalGoldPriceTable" aria-live="polite" aria-busy="true">
-                <tr class="skeleton-row" aria-hidden="true">
-                  <td>
-                    <div class="skeleton skeleton-line" style="width: 90px;"></div>
-                  </td>
-                  <td align="right">
-                    <div class="skeleton skeleton-price"></div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <p class="text-note" id="globalGoldPriceTableNote" style="padding: 0 2rem 2rem">Ini adalah harga murni sebagai acuan global, belum termasuk biaya admin atau penyesuaian lainnya.</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- restyled the global gold spot card to reuse the price highlight layout so it mirrors the daily buyback update section
- refreshed supporting styles, skeleton loader, and table presentation for the world spot data to suit the new highlight treatment

## Testing
- no tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e15d9265348330b78e10d2a31cc991