### PR TITLE
Restyle global gold spot card to match price highlight

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2084,150 +2084,80 @@ tbody tr:hover td {
   margin: 0 auto
 }
 
-/* --- World spot price card & table --- */
-.world-price-card {
-  padding: 1.4rem 1.6rem;
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+/* --- World spot highlight --- */
+.world-price-highlight {
   margin: 1.6rem auto 0;
-  container-type: inline-size;
-  container-name: world-price-card;
-}
-
-.world-price-card__head {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
   gap: 1.2rem;
-  flex-wrap: wrap;
-  row-gap: .4rem;
+  min-height: 100%;
 }
 
-.world-price-card__head .accent-title {
-  margin-bottom: .25rem;
-  letter-spacing: .12em;
-}
-
-.world-price-card .h3 {
+.world-price-highlight .price-highlight-headline .h3 {
   margin: 0;
   font-size: 1.2rem;
-  color: var(--deep);
 }
 
-.world-price-card .date-badge {
-  white-space: nowrap;
+.world-price-highlight .price-highlight-main {
+  display: flex;
+  align-items: baseline;
+  gap: .4rem;
 }
 
-.world-price-card__body {
-  display: grid;
-  grid-template-columns: minmax(0, auto) minmax(0, 1fr);
-  grid-template-areas: "value note";
-  align-items: start;
-  gap: .6rem 1.4rem;
-}
-
-.world-price-value {
-  grid-area: value;
+.world-price-highlight .price-highlight-value {
   font-size: clamp(1.8rem, 2.3vw + 1rem, 2.7rem);
-  font-weight: 700;
-  color: var(--deep);
-  letter-spacing: -.01em;
 }
 
-.world-price-card .text-note {
-  grid-area: note;
-  margin: 0;
-  color: var(--muted);
+.world-price-highlight .price-highlight-unit {
+  font-size: 1.1rem;
+  opacity: .85;
 }
 
-@container world-price-card (max-width: 520px) {
-  .world-price-card__body {
-    grid-template-columns: 1fr;
-    grid-template-areas:
-      "value"
-      "note";
-    gap: .5rem;
-  }
-}
-
-#globalGoldPriceTableCard {
-  max-width: 720px;
-  margin: 1.6rem auto 0;
-  overflow: hidden;
-}
-
-#globalGoldPriceTableCard .table-card__head {
-  padding: 1.4rem 1.6rem .8rem;
-  border-bottom: 1px solid var(--border);
+.world-price-highlight .price-highlight-insights {
   display: grid;
-  gap: .25rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
 }
 
-#globalGoldPriceTableCard .table-card__head .h3 {
+.world-price-highlight__note .price-highlight-insight-value {
+  line-height: 1.45;
+}
+
+.price-highlight-footnote {
   margin: 0;
+  color: rgba(239, 255, 252, .78);
+  font-size: .95rem;
 }
 
-#globalGoldPriceTableCard .table-card__head .text-note {
-  margin: 0;
-  color: var(--muted);
+.world-price-highlight .price-highlight-insight-label {
+  color: rgba(239, 255, 252, .76);
 }
 
-.world-price-table thead th:first-child {
-  border-top-left-radius: 0;
+.world-price-highlight .price-highlight-insight-value {
+  color: var(--paper);
 }
 
-.world-price-table thead th:last-child {
-  border-top-right-radius: 0;
-}
-
-.world-price-table tbody td:first-child {
-  font-weight: 600;
-  color: var(--deep);
-}
-
-.world-price-table tbody td:last-child {
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-  font-weight: 600;
+.world-price-highlight .date-badge {
+  background: rgba(1, 32, 36, .25);
+  color: var(--paper);
 }
 
 @media (max-width: 860px) {
-  .world-price-card {
-    padding: 1.3rem 1.4rem;
-    gap: .85rem;
+  .world-price-highlight {
+    gap: 1rem;
   }
 
-  .world-price-card__head {
-    gap: .9rem;
-  }
-
-  .world-price-value {
+  .world-price-highlight .price-highlight-value {
     font-size: clamp(1.65rem, 2.1vw + 1rem, 2.5rem);
   }
 }
 
 @media (max-width: 720px) {
-  .world-price-card {
-    padding: 1.2rem 1.25rem;
-    gap: .75rem;
-  }
-
-  .world-price-card__head {
+  .world-price-highlight .price-highlight-head {
     flex-direction: column;
     align-items: flex-start;
-    gap: .6rem;
   }
 
-  .world-price-card .date-badge {
+  .world-price-highlight .date-badge {
     font-size: .9rem;
-  }
-
-  #globalGoldPriceTableCard {
-    margin-top: 1.4rem;
   }
 }
 
@@ -5569,6 +5499,23 @@ a {
 #lmBaruHighlight[aria-busy="true"] .price-highlight-insights,
 #lmBaruHighlight[aria-busy="true"] .price-highlight-delta,
 #lmBaruHighlight[aria-busy="true"] .price-highlight-actions {
+  visibility: hidden;
+}
+
+.world-price-highlight .skeleton-content {
+  display: none;
+  flex-direction: column;
+  gap: .6rem;
+}
+
+.world-price-highlight[aria-busy="true"] .skeleton-content {
+  display: flex;
+}
+
+.world-price-highlight[aria-busy="true"] .price-highlight-head,
+.world-price-highlight[aria-busy="true"] .price-highlight-main,
+.world-price-highlight[aria-busy="true"] .price-highlight-insights,
+.world-price-highlight[aria-busy="true"] .price-highlight-footnote {
   visibility: hidden;
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2581,6 +2581,7 @@ function getGlobalGoldElements() {
   return {
     card: document.getElementById('globalGoldPriceCard'),
     perGram: document.getElementById('globalGoldPricePerGram'),
+    perOunce: document.getElementById('globalGoldPricePerOunce'),
     date: document.getElementById('globalGoldPriceDate'),
     note: document.getElementById('globalGoldPriceNote'),
     tableBody: document.getElementById('globalGoldPriceTable'),
@@ -2658,6 +2659,9 @@ function renderGlobalGoldSpot(data, targetElements) {
   if (elements.perGram) {
     elements.perGram.textContent = perGramValue !== null ? 'Rp ' + formatCurrencyIDR(perGramValue) : 'Rp —';
   }
+  if (elements.perOunce) {
+    elements.perOunce.textContent = perOunceValue !== null ? 'Rp ' + formatCurrencyIDR(perOunceValue) : 'Rp —';
+  }
   if (elements.date) {
     elements.date.textContent = dateLabel || '—';
   }
@@ -2665,19 +2669,6 @@ function renderGlobalGoldSpot(data, targetElements) {
   setGlobalNoteText(elements.note, null);
   setGlobalNoteText(elements.tableNote, null);
 
-  if (elements.tableBody) {
-    var rows = [];
-    if (perOunceValue !== null) {
-      rows.push('<tr><td>Per Troy Ounce (31,103 gram)</td><td align="right">Rp ' + formatCurrencyIDR(perOunceValue) + '</td></tr>');
-    }
-    if (perGramValue !== null) {
-      rows.push('<tr><td>Per Gram</td><td align="right">Rp ' + formatCurrencyIDR(perGramValue) + '</td></tr>');
-    }
-    if (!rows.length) {
-      rows.push('<tr><td colspan="2" class="text-note">Data harga emas dunia belum tersedia.</td></tr>');
-    }
-    elements.tableBody.innerHTML = rows.join('');
-  }
 }
 
 function renderGlobalGoldError(message, targetElements) {
@@ -2687,6 +2678,9 @@ function renderGlobalGoldError(message, targetElements) {
 
   if (elements.perGram) {
     elements.perGram.textContent = 'Rp —';
+  }
+  if (elements.perOunce) {
+    elements.perOunce.textContent = 'Rp —';
   }
   if (elements.date) {
     elements.date.textContent = '—';

--- a/harga/index.html
+++ b/harga/index.html
@@ -354,38 +354,38 @@
       <div class="container">
         <div class="accent-title">Referensi Global</div>
         <h2 class="h2">Harga Emas Spot Dunia (XAU)</h2>
-        <div id="globalGoldPriceCard" class="card world-price-card mt-12" role="status" aria-live="polite" aria-busy="true">
-          <div class="world-price-card__head">
-            <div>
-              <h3 class="h3">Nilai Murni Emas Global</h3>
+        <div id="globalGoldPriceCard" class="card price-highlight world-price-highlight mt-12" role="status" aria-live="polite" aria-busy="true">
+          <div class="skeleton-content" aria-hidden="true">
+            <div class="flex-split">
+              <div class="skeleton skeleton-line" style="width: 180px; height: 1.1rem;"></div>
+              <div class="skeleton skeleton-badge"></div>
+            </div>
+            <div class="skeleton skeleton-price" style="height: 2.4rem; width: 220px; margin-top: .2rem;"></div>
+            <div class="skeleton skeleton-line" style="width: 220px; height: 1rem; margin-top: .8rem;"></div>
+            <div class="skeleton skeleton-line" style="width: 100%; height: 52px; margin-top: .8rem;"></div>
+          </div>
+          <div class="price-highlight-head">
+            <div class="price-highlight-headline">
+              <p class="price-highlight-label">Nilai Murni Emas Global</p>
+              <h3 class="h3">Spot XAU → IDR</h3>
             </div>
             <span id="globalGoldPriceDate" class="date-badge">—</span>
           </div>
-          <div class="world-price-card__body">
-            <div class="world-price-value" id="globalGoldPricePerGram">Rp —</div>
-            <p class="text-note" id="globalGoldPriceNote">Harga per gram dalam Rupiah (kurs <span class="nowrap">XAU/IDR</span>).</p>
+          <div class="price-highlight-main">
+            <span id="globalGoldPricePerGram" class="price-highlight-value">Rp —</span>
+            <span class="price-highlight-unit">/gram</span>
           </div>
-          <div class="table-wrap">
-            <table class="world-price-table" aria-label="Tabel harga emas dunia">
-              <thead>
-                <tr>
-                  <th>Satuan</th>
-                  <th>Harga (Rp)</th>
-                </tr>
-              </thead>
-              <tbody id="globalGoldPriceTable" aria-live="polite" aria-busy="true">
-                <tr class="skeleton-row" aria-hidden="true">
-                  <td>
-                    <div class="skeleton skeleton-line" style="width: 90px;"></div>
-                  </td>
-                  <td align="right">
-                    <div class="skeleton skeleton-price"></div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+          <div class="price-highlight-insights" aria-live="polite">
+            <div class="price-highlight-insight">
+              <span class="price-highlight-insight-label">Per Troy Ounce</span>
+              <span id="globalGoldPricePerOunce" class="price-highlight-insight-value">Rp —</span>
+            </div>
+            <div class="price-highlight-insight world-price-highlight__note">
+              <span class="price-highlight-insight-label">Catatan</span>
+              <span class="price-highlight-insight-value price-highlight-insight-value--stack" id="globalGoldPriceNote">Harga per gram dalam Rupiah (kurs XAU/IDR).</span>
+            </div>
           </div>
-          <p class="text-note" id="globalGoldPriceTableNote" style="padding: 0 2rem 2rem">Ini adalah harga murni sebagai acuan global, belum termasuk biaya admin atau penyesuaian lainnya.</p>
+          <p class="price-highlight-footnote text-note" id="globalGoldPriceTableNote">Ini adalah harga murni sebagai acuan global, belum termasuk biaya admin atau penyesuaian lainnya.</p>
         </div>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -489,38 +489,38 @@
       <div class="container">
         <div class="accent-title">Referensi Global</div>
         <h2 class="h2">Harga Emas Spot Dunia (XAU)</h2>
-        <div id="globalGoldPriceCard" class="card world-price-card mt-12" role="status" aria-live="polite" aria-busy="true">
-          <div class="world-price-card__head">
-            <div>
-              <h3 class="h3">Nilai Murni Emas Global</h3>
+        <div id="globalGoldPriceCard" class="card price-highlight world-price-highlight mt-12" role="status" aria-live="polite" aria-busy="true">
+          <div class="skeleton-content" aria-hidden="true">
+            <div class="flex-split">
+              <div class="skeleton skeleton-line" style="width: 180px; height: 1.1rem;"></div>
+              <div class="skeleton skeleton-badge"></div>
+            </div>
+            <div class="skeleton skeleton-price" style="height: 2.4rem; width: 220px; margin-top: .2rem;"></div>
+            <div class="skeleton skeleton-line" style="width: 220px; height: 1rem; margin-top: .8rem;"></div>
+            <div class="skeleton skeleton-line" style="width: 100%; height: 52px; margin-top: .8rem;"></div>
+          </div>
+          <div class="price-highlight-head">
+            <div class="price-highlight-headline">
+              <p class="price-highlight-label">Nilai Murni Emas Global</p>
+              <h3 class="h3">Spot XAU → IDR</h3>
             </div>
             <span id="globalGoldPriceDate" class="date-badge">—</span>
           </div>
-          <div class="world-price-card__body">
-            <div class="world-price-value" id="globalGoldPricePerGram">Rp —</div>
-            <p class="text-note" id="globalGoldPriceNote">Harga per gram dalam Rupiah (kurs <span class="nowrap">XAU/IDR</span>).</p>
+          <div class="price-highlight-main">
+            <span id="globalGoldPricePerGram" class="price-highlight-value">Rp —</span>
+            <span class="price-highlight-unit">/gram</span>
           </div>
-          <div class="table-wrap">
-            <table class="world-price-table" aria-label="Tabel harga emas dunia">
-              <thead>
-                <tr>
-                  <th>Satuan</th>
-                  <th>Harga (Rp)</th>
-                </tr>
-              </thead>
-              <tbody id="globalGoldPriceTable" aria-live="polite" aria-busy="true">
-                <tr class="skeleton-row" aria-hidden="true">
-                  <td>
-                    <div class="skeleton skeleton-line" style="width: 90px;"></div>
-                  </td>
-                  <td align="right">
-                    <div class="skeleton skeleton-price"></div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+          <div class="price-highlight-insights" aria-live="polite">
+            <div class="price-highlight-insight">
+              <span class="price-highlight-insight-label">Per Troy Ounce</span>
+              <span id="globalGoldPricePerOunce" class="price-highlight-insight-value">Rp —</span>
+            </div>
+            <div class="price-highlight-insight world-price-highlight__note">
+              <span class="price-highlight-insight-label">Catatan</span>
+              <span class="price-highlight-insight-value price-highlight-insight-value--stack" id="globalGoldPriceNote">Harga per gram dalam Rupiah (kurs XAU/IDR).</span>
+            </div>
           </div>
-          <p class="text-note" id="globalGoldPriceTableNote" style="padding: 0 2rem 2rem">Ini adalah harga murni sebagai acuan global, belum termasuk biaya admin atau penyesuaian lainnya.</p>
+          <p class="price-highlight-footnote text-note" id="globalGoldPriceTableNote">Ini adalah harga murni sebagai acuan global, belum termasuk biaya admin atau penyesuaian lainnya.</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- restyle the global gold spot section to reuse the price highlight layout and skeleton states on both home and harga pages
- update styles to support the new world price highlight presentation and responsive behaviour
- adjust JavaScript bindings to populate the per-gram, per-ounce, and note fields in the refreshed card

## Testing
- not run (static HTML/CSS/JS updates)


------
https://chatgpt.com/codex/tasks/task_e_68e15d9265348330b78e10d2a31cc991