### PR TITLE
Improve world price date badge contrast

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2084,150 +2084,114 @@ tbody tr:hover td {
   margin: 0 auto
 }
 
-/* --- World spot price card & table --- */
+/* --- World spot price highlight --- */
 .world-price-card {
-  padding: 1.4rem 1.6rem;
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
   margin: 1.6rem auto 0;
-  container-type: inline-size;
-  container-name: world-price-card;
+  max-width: 720px;
+  gap: 1.1rem;
 }
 
-.world-price-card__head {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 1.2rem;
-  flex-wrap: wrap;
-  row-gap: .4rem;
+.world-price-card .price-highlight-headline {
+  gap: .35rem;
 }
 
-.world-price-card__head .accent-title {
-  margin-bottom: .25rem;
-  letter-spacing: .12em;
-}
-
-.world-price-card .h3 {
-  margin: 0;
+.world-price-card .price-highlight-title {
   font-size: 1.2rem;
-  color: var(--deep);
+  font-weight: 700;
+  color: rgba(239, 255, 252, .96);
+  letter-spacing: -.01em;
 }
 
 .world-price-card .date-badge {
   white-space: nowrap;
+  --badge-bg: rgba(239, 255, 252, .16);
+  --badge-border: rgba(239, 255, 252, .38);
+  --badge-color: rgba(239, 255, 252, .94);
+  --badge-shadow: inset 0 1px 0 rgba(255, 255, 255, .25);
 }
 
-.world-price-card__body {
+[data-theme="dark"] .world-price-card .date-badge {
+  --badge-bg: rgba(239, 255, 252, .18);
+  --badge-border: rgba(239, 255, 252, .42);
+  --badge-color: rgba(255, 255, 255, .96);
+  --badge-shadow: inset 0 1px 0 rgba(255, 255, 255, .2);
+}
+
+.world-price-card .price-highlight-main {
+  align-items: baseline;
+  gap: .6rem;
+}
+
+.world-price-card .price-highlight-value {
+  font-size: clamp(1.9rem, 2.4vw + 1rem, 2.8rem);
+}
+
+.world-price-card .price-highlight-unit {
+  font-size: 1rem;
+  color: rgba(239, 255, 252, .82);
+}
+
+.world-price-card .price-highlight-note {
+  margin: 0;
+  color: rgba(225, 250, 246, .78);
+}
+
+.world-price-insights {
   display: grid;
-  grid-template-columns: minmax(0, auto) minmax(0, 1fr);
-  grid-template-areas: "value note";
-  align-items: start;
-  gap: .6rem 1.4rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: .9rem;
 }
 
-.world-price-value {
-  grid-area: value;
-  font-size: clamp(1.8rem, 2.3vw + 1rem, 2.7rem);
-  font-weight: 700;
-  color: var(--deep);
-  letter-spacing: -.01em;
+.world-price-card .price-highlight-insight-value {
+  font-size: 1.08rem;
 }
 
-.world-price-card .text-note {
-  grid-area: note;
-  margin: 0;
-  color: var(--muted);
+.world-price-card .skeleton-content {
+  display: none;
+  flex-direction: column;
+  gap: .7rem;
 }
 
-@container world-price-card (max-width: 520px) {
-  .world-price-card__body {
-    grid-template-columns: 1fr;
-    grid-template-areas:
-      "value"
-      "note";
-    gap: .5rem;
-  }
+.world-price-card[aria-busy="true"] .skeleton-content {
+  display: flex;
 }
 
-#globalGoldPriceTableCard {
-  max-width: 720px;
-  margin: 1.6rem auto 0;
-  overflow: hidden;
-}
-
-#globalGoldPriceTableCard .table-card__head {
-  padding: 1.4rem 1.6rem .8rem;
-  border-bottom: 1px solid var(--border);
-  display: grid;
-  gap: .25rem;
-}
-
-#globalGoldPriceTableCard .table-card__head .h3 {
-  margin: 0;
-}
-
-#globalGoldPriceTableCard .table-card__head .text-note {
-  margin: 0;
-  color: var(--muted);
-}
-
-.world-price-table thead th:first-child {
-  border-top-left-radius: 0;
-}
-
-.world-price-table thead th:last-child {
-  border-top-right-radius: 0;
-}
-
-.world-price-table tbody td:first-child {
-  font-weight: 600;
-  color: var(--deep);
-}
-
-.world-price-table tbody td:last-child {
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-  font-weight: 600;
+.world-price-card[aria-busy="true"] .price-highlight-head,
+.world-price-card[aria-busy="true"] .price-highlight-main,
+.world-price-card[aria-busy="true"] .price-highlight-insights,
+.world-price-card[aria-busy="true"] .price-highlight-note {
+  visibility: hidden;
 }
 
 @media (max-width: 860px) {
   .world-price-card {
+    gap: .95rem;
     padding: 1.3rem 1.4rem;
-    gap: .85rem;
   }
 
-  .world-price-card__head {
-    gap: .9rem;
-  }
-
-  .world-price-value {
-    font-size: clamp(1.65rem, 2.1vw + 1rem, 2.5rem);
+  .world-price-card .price-highlight-value {
+    font-size: clamp(1.75rem, 2.2vw + 1rem, 2.6rem);
   }
 }
 
 @media (max-width: 720px) {
   .world-price-card {
     padding: 1.2rem 1.25rem;
-    gap: .75rem;
+    gap: .85rem;
   }
 
-  .world-price-card__head {
+  .world-price-card .price-highlight-head {
     flex-direction: column;
     align-items: flex-start;
     gap: .6rem;
   }
 
   .world-price-card .date-badge {
-    font-size: .9rem;
+    font-size: .92rem;
   }
 
-  #globalGoldPriceTableCard {
-    margin-top: 1.4rem;
+  .world-price-insights {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   }
 }
 

--- a/harga/index.html
+++ b/harga/index.html
@@ -354,38 +354,39 @@
       <div class="container">
         <div class="accent-title">Referensi Global</div>
         <h2 class="h2">Harga Emas Spot Dunia (XAU)</h2>
-        <div id="globalGoldPriceCard" class="card world-price-card mt-12" role="status" aria-live="polite" aria-busy="true">
-          <div class="world-price-card__head">
-            <div>
-              <h3 class="h3">Nilai Murni Emas Global</h3>
+        <div id="globalGoldPriceCard" class="card price-highlight world-price-card mt-12" role="status" aria-live="polite" aria-busy="true">
+          <div class="skeleton-content" aria-hidden="true">
+            <div class="flex-split">
+              <div class="skeleton skeleton-line" style="width: 160px; height: 1.1rem;"></div>
+              <div class="skeleton skeleton-badge"></div>
+            </div>
+            <div class="skeleton skeleton-price" style="height: 2.4rem; width: 200px; margin-top: .2rem;"></div>
+            <div class="skeleton skeleton-line" style="width: 240px; margin-top: .6rem;"></div>
+            <div class="skeleton skeleton-line" style="width: 100%; height: 48px; margin-top: 1rem;"></div>
+          </div>
+          <div class="price-highlight-head">
+            <div class="price-highlight-headline">
+              <p class="price-highlight-label">Nilai Murni Emas Global</p>
+              <span class="price-highlight-title">Harga Spot Dunia</span>
             </div>
             <span id="globalGoldPriceDate" class="date-badge">—</span>
           </div>
-          <div class="world-price-card__body">
-            <div class="world-price-value" id="globalGoldPricePerGram">Rp —</div>
-            <p class="text-note" id="globalGoldPriceNote">Harga per gram dalam Rupiah (kurs <span class="nowrap">XAU/IDR</span>).</p>
+          <div class="price-highlight-main">
+            <span id="globalGoldPricePerGram" class="price-highlight-value">Rp —</span>
+            <span class="price-highlight-unit">/gram</span>
           </div>
-          <div class="table-wrap">
-            <table class="world-price-table" aria-label="Tabel harga emas dunia">
-              <thead>
-                <tr>
-                  <th>Satuan</th>
-                  <th>Harga (Rp)</th>
-                </tr>
-              </thead>
-              <tbody id="globalGoldPriceTable" aria-live="polite" aria-busy="true">
-                <tr class="skeleton-row" aria-hidden="true">
-                  <td>
-                    <div class="skeleton skeleton-line" style="width: 90px;"></div>
-                  </td>
-                  <td align="right">
-                    <div class="skeleton skeleton-price"></div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+          <p class="price-highlight-note text-note" id="globalGoldPriceNote">Harga per gram dalam Rupiah (kurs <span class="nowrap">XAU/IDR</span>).</p>
+          <div class="price-highlight-insights world-price-insights">
+            <div class="price-highlight-insight">
+              <span class="price-highlight-insight-label">Per Troy Ounce (31,103 gram)</span>
+              <span id="globalGoldPricePerOunce" class="price-highlight-insight-value">Rp —</span>
+            </div>
+            <div class="price-highlight-insight">
+              <span class="price-highlight-insight-label">Per 10 Gram</span>
+              <span id="globalGoldPricePerTenGram" class="price-highlight-insight-value">Rp —</span>
+            </div>
           </div>
-          <p class="text-note" id="globalGoldPriceTableNote" style="padding: 0 2rem 2rem">Ini adalah harga murni sebagai acuan global, belum termasuk biaya admin atau penyesuaian lainnya.</p>
+          <p class="price-highlight-note text-note" id="globalGoldPriceTableNote">Ini adalah harga murni sebagai acuan global, belum termasuk biaya admin atau penyesuaian lainnya.</p>
         </div>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -489,38 +489,39 @@
       <div class="container">
         <div class="accent-title">Referensi Global</div>
         <h2 class="h2">Harga Emas Spot Dunia (XAU)</h2>
-        <div id="globalGoldPriceCard" class="card world-price-card mt-12" role="status" aria-live="polite" aria-busy="true">
-          <div class="world-price-card__head">
-            <div>
-              <h3 class="h3">Nilai Murni Emas Global</h3>
+        <div id="globalGoldPriceCard" class="card price-highlight world-price-card mt-12" role="status" aria-live="polite" aria-busy="true">
+          <div class="skeleton-content" aria-hidden="true">
+            <div class="flex-split">
+              <div class="skeleton skeleton-line" style="width: 160px; height: 1.1rem;"></div>
+              <div class="skeleton skeleton-badge"></div>
+            </div>
+            <div class="skeleton skeleton-price" style="height: 2.4rem; width: 200px; margin-top: .2rem;"></div>
+            <div class="skeleton skeleton-line" style="width: 240px; margin-top: .6rem;"></div>
+            <div class="skeleton skeleton-line" style="width: 100%; height: 48px; margin-top: 1rem;"></div>
+          </div>
+          <div class="price-highlight-head">
+            <div class="price-highlight-headline">
+              <p class="price-highlight-label">Nilai Murni Emas Global</p>
+              <span class="price-highlight-title">Harga Spot Dunia</span>
             </div>
             <span id="globalGoldPriceDate" class="date-badge">—</span>
           </div>
-          <div class="world-price-card__body">
-            <div class="world-price-value" id="globalGoldPricePerGram">Rp —</div>
-            <p class="text-note" id="globalGoldPriceNote">Harga per gram dalam Rupiah (kurs <span class="nowrap">XAU/IDR</span>).</p>
+          <div class="price-highlight-main">
+            <span id="globalGoldPricePerGram" class="price-highlight-value">Rp —</span>
+            <span class="price-highlight-unit">/gram</span>
           </div>
-          <div class="table-wrap">
-            <table class="world-price-table" aria-label="Tabel harga emas dunia">
-              <thead>
-                <tr>
-                  <th>Satuan</th>
-                  <th>Harga (Rp)</th>
-                </tr>
-              </thead>
-              <tbody id="globalGoldPriceTable" aria-live="polite" aria-busy="true">
-                <tr class="skeleton-row" aria-hidden="true">
-                  <td>
-                    <div class="skeleton skeleton-line" style="width: 90px;"></div>
-                  </td>
-                  <td align="right">
-                    <div class="skeleton skeleton-price"></div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+          <p class="price-highlight-note text-note" id="globalGoldPriceNote">Harga per gram dalam Rupiah (kurs <span class="nowrap">XAU/IDR</span>).</p>
+          <div class="price-highlight-insights world-price-insights">
+            <div class="price-highlight-insight">
+              <span class="price-highlight-insight-label">Per Troy Ounce (31,103 gram)</span>
+              <span id="globalGoldPricePerOunce" class="price-highlight-insight-value">Rp —</span>
+            </div>
+            <div class="price-highlight-insight">
+              <span class="price-highlight-insight-label">Per 10 Gram</span>
+              <span id="globalGoldPricePerTenGram" class="price-highlight-insight-value">Rp —</span>
+            </div>
           </div>
-          <p class="text-note" id="globalGoldPriceTableNote" style="padding: 0 2rem 2rem">Ini adalah harga murni sebagai acuan global, belum termasuk biaya admin atau penyesuaian lainnya.</p>
+          <p class="price-highlight-note text-note" id="globalGoldPriceTableNote">Ini adalah harga murni sebagai acuan global, belum termasuk biaya admin atau penyesuaian lainnya.</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- increase the contrast of the world spot price date badge on both themes
- ensure the badge inherits a light text color and subtle glow against the dark highlight card

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e15d9265348330b78e10d2a31cc991