### PR TITLE
Add comparison table section to homepage

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3688,6 +3688,157 @@ a {
   background: rgba(212, 175, 55, .18)
 }
 
+/* ---------- comparison table ---------- */
+.comparison-section {
+  padding: clamp(2.6rem, 3.6vw + 1rem, 4.2rem) 0;
+  background: var(--bg-secondary)
+}
+
+.comparison-table-wrap {
+  margin-top: 1.6rem
+}
+
+.comparison-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+  background: var(--paper);
+  box-shadow: var(--shadow);
+  border-radius: 18px;
+  overflow: hidden
+}
+
+.comparison-table th,
+.comparison-table td {
+  padding: 1.1rem 1.2rem;
+  border: 1px solid var(--border-subtle);
+  vertical-align: top;
+  text-align: left;
+  color: var(--text-secondary);
+  font-size: 1rem;
+  line-height: 1.6
+}
+
+.comparison-table thead th {
+  background: var(--bg-tertiary);
+  color: var(--accent-green);
+  font-size: 1.05rem;
+  font-weight: 700
+}
+
+.comparison-table tbody th[scope="row"] {
+  color: var(--accent-green);
+  background: rgba(212, 175, 55, .08);
+  font-weight: 700;
+  min-width: 200px
+}
+
+.comparison-table tbody tr:nth-child(even) td {
+  background: rgba(1, 61, 57, .02)
+}
+
+.comparison-badge {
+  margin-left: .4rem;
+  white-space: nowrap
+}
+
+.comparison-cta {
+  margin-top: 2.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.4rem;
+  background: var(--paper);
+  border: 1px solid var(--border-subtle);
+  border-radius: 18px;
+  box-shadow: var(--shadow)
+}
+
+.comparison-cta__content {
+  display: flex;
+  flex-direction: column;
+  gap: .5rem
+}
+
+.comparison-cta .h3 {
+  margin: 0;
+  color: var(--accent-green)
+}
+
+.comparison-cta p {
+  margin: 0
+}
+
+@media (max-width: 900px) {
+  .comparison-table {
+    min-width: 100%;
+    font-size: .98rem
+  }
+
+  .comparison-table th,
+  .comparison-table td {
+    padding: .9rem 1rem
+  }
+
+  .comparison-cta {
+    flex-direction: column;
+    align-items: flex-start
+  }
+}
+
+@media (max-width: 720px) {
+  .comparison-table {
+    border-radius: 18px;
+    overflow: hidden;
+    box-shadow: none;
+    border: none
+  }
+
+  .comparison-table thead {
+    display: none
+  }
+
+  .comparison-table tbody {
+    display: grid;
+    gap: 1.2rem
+  }
+
+  .comparison-table tr {
+    border: 1px solid var(--border-subtle);
+    border-radius: 18px;
+    overflow: hidden;
+    background: var(--paper);
+    box-shadow: var(--shadow)
+  }
+
+  .comparison-table tbody th[scope="row"] {
+    display: block;
+    border: 0;
+    border-bottom: 1px solid var(--border-subtle);
+    padding: .95rem 1.1rem;
+    background: rgba(212, 175, 55, .12)
+  }
+
+  .comparison-table td {
+    display: block;
+    border: 0;
+    border-top: 1px solid var(--border-subtle);
+    padding: .9rem 1.1rem
+  }
+
+  .comparison-table td::before {
+    content: attr(data-label);
+    display: block;
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-bottom: .35rem
+  }
+
+  .comparison-table tbody tr:nth-child(even) td {
+    background: transparent
+  }
+}
+
 .price-row[role="button"]:focus-visible td {
   background: rgba(212, 175, 55, .24)
 }

--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@
       </a>
       <nav class="menu" itemscope itemtype="https://schema.org/SiteNavigationElement" aria-label="Navigasi utama">
         <a itemprop="url" href="#fitur"><span itemprop="name">Fitur</span></a>
+        <a itemprop="url" href="#komparasi"><span itemprop="name">Komparasi</span></a>
         <a itemprop="url" href="#diterima"><span itemprop="name">Yang Diterima</span></a>
         <a itemprop="url" href="#harga"><span itemprop="name">Harga Buyback</span></a>
         <a itemprop="url" href="#kontak"><span itemprop="name">Kontak</span></a>
@@ -602,6 +603,72 @@
               </li>
             </ol>
           </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== KOMPARASI ===================== -->
+    <section id="komparasi" class="comparison-section" data-scroll-section>
+      <div class="container">
+        <div class="accent-title">Bandingkan Pilihan</div>
+        <h2 class="h2">Sentral Emas vs Alternatif Buyback</h2>
+        <p class="text-muted mw-70ch">Lihat sekilas perbedaan layanan kami dibandingkan opsi populer lain agar Anda bisa menentukan tempat jual emas dan berlian yang paling aman serta menguntungkan.</p>
+        <div class="table-wrap comparison-table-wrap">
+          <table class="comparison-table">
+            <thead>
+              <tr>
+                <th scope="col">Kriteria</th>
+                <th scope="col">Sentral Emas</th>
+                <th scope="col">Pegadaian</th>
+                <th scope="col">Toko Emas Biasa</th>
+                <th scope="col">Marketplace</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">Kecepatan Cair Dana</th>
+                <td data-label="Sentral Emas">Langsung cair di lokasi transaksi dengan proses ±5 menit <span class="comparison-badge badge badge--accent">Unggul</span></td>
+                <td data-label="Pegadaian">Perlu antre dan administrasi; pencairan mengikuti prosedur loket.</td>
+                <td data-label="Toko Emas Biasa">Bergantung toko; sering butuh penilaian ulang dan negosiasi manual.</td>
+                <td data-label="Marketplace">Dana baru masuk setelah barang terjual, dikirim, dan diverifikasi pembeli.</td>
+              </tr>
+              <tr>
+                <th scope="row">Transparansi Penilaian</th>
+                <td data-label="Sentral Emas">Tes kadar &amp; keaslian dilakukan di hadapan Anda dengan alat standar <span class="comparison-badge badge badge--accent">Unggul</span></td>
+                <td data-label="Pegadaian">Penilaian mengikuti SOP internal, hasil disampaikan setelah proses selesai.</td>
+                <td data-label="Toko Emas Biasa">Sebagian toko tidak membuka detail penilaian kadar dan potongan.</td>
+                <td data-label="Marketplace">Penilaian dilakukan pembeli; risiko komplain bila deskripsi dianggap kurang jelas.</td>
+              </tr>
+              <tr>
+                <th scope="row">Fleksibilitas Lokasi</th>
+                <td data-label="Sentral Emas">COD datang ke rumah/kantor/kafe se-Jabodetabek sesuai jadwal Anda <span class="comparison-badge badge badge--accent">Unggul</span></td>
+                <td data-label="Pegadaian">Harus datang ke cabang terdekat sesuai jam operasional.</td>
+                <td data-label="Toko Emas Biasa">Harus ke toko; jam buka terbatas &amp; lokasi tertentu saja.</td>
+                <td data-label="Marketplace">Transaksi sepenuhnya online, perlu pengiriman dan koordinasi logistik.</td>
+              </tr>
+              <tr>
+                <th scope="row">Harga Buyback</th>
+                <td data-label="Sentral Emas">Mengacu harga pasar harian tanpa potongan tersembunyi <span class="comparison-badge badge badge--accent">Unggul</span></td>
+                <td data-label="Pegadaian">Mengikuti tabel internal dengan potongan administrasi tertentu.</td>
+                <td data-label="Toko Emas Biasa">Harga sangat bervariasi; kerap lebih rendah untuk emas tanpa surat.</td>
+                <td data-label="Marketplace">Harga ditentukan pasar bebas; potensi underpricing saat butuh cepat.</td>
+              </tr>
+              <tr>
+                <th scope="row">Konsultasi Awal</th>
+                <td data-label="Sentral Emas">Tim siap bantu review foto &amp; estimasi harga secara gratis <span class="comparison-badge badge badge--accent">Unggul</span></td>
+                <td data-label="Pegadaian">Informasi umum tersedia, konsultasi detail harus datang langsung.</td>
+                <td data-label="Toko Emas Biasa">Biasanya hanya saat sudah di toko; tidak semua menyediakan konsultasi.</td>
+                <td data-label="Marketplace">Harus mandiri; tidak ada pendampingan resmi dari platform.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="comparison-cta card pad-1">
+          <div class="comparison-cta__content">
+            <h3 class="h3">Masih ragu? Buktikan sendiri.</h3>
+            <p class="text-muted">Langsung konsultasi via WhatsApp untuk cek estimasi harga dan jadwalkan COD sesuai kenyamanan Anda.</p>
+          </div>
+          <a class="btn btn-gold" href="https://wa.me/6285591088503" target="_blank" rel="noopener noreferrer" data-track="wa-komparasi">Buktikan lewat konsultasi WhatsApp</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add a Komparasi navigation link and new homepage section comparing Sentral Emas with alternative services
- implement responsive comparison table styling and highlight Sentral Emas advantages with a WhatsApp CTA

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e29fb49bc08330bf9073a49ba231a8