### PR TITLE
Improve theme transition animations

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -263,7 +263,8 @@ html,
 body {
   margin: 0;
   height: 100%;
-  scroll-behavior: smooth
+  scroll-behavior: smooth;
+  transition: background-color .3s ease, color .3s ease
 }
 
 body {
@@ -390,7 +391,8 @@ body {
   background: var(--paper);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  box-shadow: var(--shadow)
+  box-shadow: var(--shadow);
+  transition: background-color .3s ease, color .3s ease, border-color .3s ease, box-shadow .3s ease
 }
 
 .h1 {
@@ -463,7 +465,8 @@ header {
   display: flex;
   align-items: center;
   gap: 1.2rem;
-  padding: 1rem 0
+  padding: 1rem 0;
+  transition: background-color .3s ease, color .3s ease
 }
 
 .brand {
@@ -702,18 +705,51 @@ nav a {
 #darkModeToggle .moon-icon,
 #darkModeToggle .auto-icon {
   display: none;
+  opacity: 0;
+  transform: rotate(-180deg) scale(.75);
+  transform-origin: 50% 50%;
+  transition: transform .4s ease, opacity .4s ease
 }
 
 #darkModeToggle[data-theme-mode="light"] .sun-icon {
   display: block;
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+  transition: transform .4s ease, opacity .4s ease
 }
 
 #darkModeToggle[data-theme-mode="dark"] .moon-icon {
   display: block;
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+  transition: transform .4s ease, opacity .4s ease
 }
 
 #darkModeToggle[data-theme-mode="auto"] .auto-icon {
   display: block;
+  opacity: 1;
+  transform: rotate(0deg) scale(1);
+  transition: transform .4s ease, opacity .4s ease
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html,
+  body,
+  .nav,
+  .card,
+  .price-highlight,
+  #darkModeToggle .sun-icon,
+  #darkModeToggle .moon-icon,
+  #darkModeToggle .auto-icon {
+    transition: none !important;
+  }
+
+  #darkModeToggle .sun-icon,
+  #darkModeToggle .moon-icon,
+  #darkModeToggle .auto-icon {
+    transform: none !important;
+    opacity: 1;
+  }
 }
 
 /* --- Scroll progress bar --- */
@@ -2192,7 +2228,7 @@ tbody tr:hover td {
   display: flex;
   flex-direction: column;
   gap: .9rem;
-  transition: transform .3s ease, box-shadow .3s ease
+  transition: background-color .3s ease, color .3s ease, transform .3s ease, box-shadow .3s ease
 }
 
 .price-highlight::after {


### PR DESCRIPTION
## Summary
- add smooth background and text transitions for the base layout, navigation, cards, and price highlight components
- animate the dark mode toggle icons with rotation and scaling when the theme changes
- respect `prefers-reduced-motion` by disabling the added transitions and transforms when requested

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2a80805948330bfd1eb99baae7bfe