### PR TITLE
Add scroll reveal animations for value section elements

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3552,6 +3552,40 @@ a {
 }
 
 /* ---------- value grid ---------- */
+@keyframes valueCardRise {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, 18px, 0);
+  }
+
+  60% {
+    opacity: 1;
+    transform: translate3d(0, -3px, 0);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes stepGlow {
+  0% {
+    box-shadow: 0 0 0 0 rgba(212, 175, 55, .28);
+    transform: scale(1);
+  }
+
+  55% {
+    box-shadow: 0 0 0 10px rgba(212, 175, 55, 0);
+    transform: scale(1.05);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgba(212, 175, 55, 0);
+    transform: scale(1);
+  }
+}
+
 .value-section {
   padding: clamp(2.6rem, 3.8vw + 1rem, 4.4rem) 0;
   background: var(--bg-tertiary)
@@ -3666,6 +3700,71 @@ a {
   background: rgba(212, 175, 55, .24);
   color: var(--accent-green);
   font-weight: 700
+}
+
+.js-enabled .value-section .value-card,
+.js-enabled .value-section .value-steps li {
+  opacity: 0;
+  transform: translate3d(0, 18px, 0);
+}
+
+.js-enabled .value-section.is-visible .value-card {
+  animation: valueCardRise .6s ease forwards;
+}
+
+.js-enabled .value-section.is-visible .value-card:nth-child(2) {
+  animation-delay: .1s;
+}
+
+.js-enabled .value-section.is-visible .value-card:nth-child(3) {
+  animation-delay: .2s;
+}
+
+.js-enabled .value-section.is-visible .value-card:nth-child(4) {
+  animation-delay: .3s;
+}
+
+.js-enabled .value-section.is-visible .value-card:nth-child(5) {
+  animation-delay: .4s;
+}
+
+.js-enabled .value-section.is-visible .value-card:nth-child(6) {
+  animation-delay: .5s;
+}
+
+.js-enabled .value-section.is-visible .value-steps li {
+  animation: valueCardRise .6s ease forwards;
+}
+
+.js-enabled .value-section.is-visible .value-steps li:nth-child(2) {
+  animation-delay: .12s;
+}
+
+.js-enabled .value-section.is-visible .value-steps li:nth-child(3) {
+  animation-delay: .24s;
+}
+
+.js-enabled .value-section.is-visible .value-steps li:nth-child(4) {
+  animation-delay: .36s;
+}
+
+.js-enabled .value-section.is-visible .value-steps li .step-chip {
+  animation: stepGlow 2.6s ease-in-out infinite;
+  animation-delay: inherit;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .js-enabled .value-section .value-card,
+  .js-enabled .value-section .value-steps li {
+    opacity: 1;
+    transform: none;
+  }
+
+  .js-enabled .value-section.is-visible .value-card,
+  .js-enabled .value-section.is-visible .value-steps li,
+  .js-enabled .value-section.is-visible .value-steps li .step-chip {
+    animation: none;
+  }
 }
 
 @media (max-width:980px) {


### PR DESCRIPTION
## Summary
- add dedicated valueCardRise and stepGlow keyframes to animate the value section
- trigger staggered entrance animations for value cards and steps when the section becomes visible
- disable the new motion effects for users who prefer reduced motion

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2a6a901108330bfacf580d0104678