### PR TITLE
Improve search overlay transition

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -996,13 +996,31 @@ body.search-active {
   background: var(--bg-primary);
   z-index: 40;
   overflow-y: auto;
-  display: none;
-  /* Hidden by default */
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translate3d(0, 16px, 0);
+  transition: opacity .25s ease, transform .25s ease, visibility 0s linear .25s;
 }
 
-body.search-active .search-section {
-  display: block;
-  /* Shown when search is active */
+.search-section.is-visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translate3d(0, 0, 0);
+  transition-delay: 0s, 0s, 0s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .search-section {
+    transition: none;
+    transform: none;
+  }
+
+  .search-section.is-visible {
+    transition-delay: 0s, 0s, 0s;
+    transform: none;
+  }
 }
 
 .search-empty[hidden] {


### PR DESCRIPTION
## Summary
- replace the search overlay display toggle with opacity/visibility transitions and a reduced-motion fallback
- manage the search results panel visibility in JavaScript so hidden is removed before animating in and restored after fade-out

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e324e92ef88330a4fedfcc5d72c544