### PR TITLE
Improve search overlay transitions

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -996,13 +996,34 @@ body.search-active {
   background: var(--bg-primary);
   z-index: 40;
   overflow-y: auto;
-  display: none;
-  /* Hidden by default */
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translate3d(0, 16px, 0);
+  transition: opacity .28s ease, visibility .28s ease, transform .32s ease;
+  will-change: opacity, transform;
 }
 
-body.search-active .search-section {
-  display: block;
-  /* Shown when search is active */
+.search-section.is-visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translate3d(0, 0, 0);
+}
+
+.search-section.is-animating {
+  will-change: opacity, transform;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .search-section {
+    transition: opacity .2s ease, visibility .2s ease;
+    transform: none;
+  }
+
+  .search-section.is-visible {
+    transform: none;
+  }
 }
 
 .search-empty[hidden] {


### PR DESCRIPTION
## Summary
- animate the search overlay with opacity, visibility, and transform transitions instead of toggling display
- add JavaScript helpers that synchronize the hidden attribute with the animation lifecycle and respect reduced-motion preferences
- ensure the search overlay only becomes interactive when visible while keeping the page state classes intact

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e324e92ef88330a4fedfcc5d72c544