### PR TITLE
Enhance header theme toggle accessibility

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -564,37 +564,64 @@ nav a {
   align-items: center;
   gap: .55rem;
   flex: 0 0 auto;
-  min-width: 0
+  min-width: 0;
+  position: relative
 }
 
 .mode-status {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: .32rem .62rem;
+  position: absolute;
+  left: -999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  border: 0;
   border-radius: 999px;
   font-size: .72rem;
   font-weight: 600;
   letter-spacing: .01em;
-  color: rgba(244, 255, 253, .94);
-  background: rgba(255, 255, 255, .12);
-  border: 1px solid rgba(255, 255, 255, .24);
   line-height: 1.1;
   white-space: nowrap;
-  text-transform: none;
-  transition: background-color .2s ease, color .2s ease, border-color .2s ease
+  color: var(--ink);
+  background: var(--paper)
 }
 
-.mode-status[data-applied-mode="light"] {
-  color: #013D39;
-  background: rgba(255, 255, 255, .96);
-  border-color: rgba(1, 61, 57, .22)
+.mode-toggle button:focus-visible + .mode-status {
+  left: 50%;
+  top: calc(100% + .65rem);
+  width: auto;
+  height: auto;
+  padding: .35rem .7rem;
+  overflow: visible;
+  clip: auto;
+  clip-path: none;
+  border: 1px solid var(--border);
+  box-shadow: 0 12px 24px rgba(1, 33, 30, .2);
+  transform: translateX(-50%);
+  white-space: nowrap;
+  z-index: 60
 }
 
-.mode-status[data-applied-mode="dark"] {
-  color: rgba(244, 255, 253, .95);
-  background: rgba(255, 255, 255, .14);
-  border-color: rgba(255, 255, 255, .26)
+@supports not selector(:focus-visible) {
+  .mode-toggle button:focus + .mode-status {
+    left: 50%;
+    top: calc(100% + .65rem);
+    width: auto;
+    height: auto;
+    padding: .35rem .7rem;
+    overflow: visible;
+    clip: auto;
+    clip-path: none;
+    border: 1px solid var(--border);
+    box-shadow: 0 12px 24px rgba(1, 33, 30, .2);
+    transform: translateX(-50%);
+    white-space: nowrap;
+    z-index: 60
+  }
 }
 
 .header-search {
@@ -992,17 +1019,6 @@ nav a {
     flex-wrap: nowrap
   }
 
-  .mode-toggle {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: .25rem
-  }
-
-  .mode-status {
-    font-size: .68rem;
-    padding: .28rem .56rem
-  }
-
   .header-search {
     margin-left: auto;
     position: static
@@ -1022,13 +1038,6 @@ nav a {
 
   .header-search.header-search--expanded .site-search {
     transform: translate(-50%, 0)
-  }
-}
-
-@media (max-width:480px) {
-  .mode-status {
-    white-space: normal;
-    text-align: left
   }
 }
 

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -559,6 +559,44 @@ nav a {
   flex: 0 0 auto
 }
 
+.mode-toggle {
+  display: flex;
+  align-items: center;
+  gap: .55rem;
+  flex: 0 0 auto;
+  min-width: 0
+}
+
+.mode-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: .32rem .62rem;
+  border-radius: 999px;
+  font-size: .72rem;
+  font-weight: 600;
+  letter-spacing: .01em;
+  color: rgba(244, 255, 253, .94);
+  background: rgba(255, 255, 255, .12);
+  border: 1px solid rgba(255, 255, 255, .24);
+  line-height: 1.1;
+  white-space: nowrap;
+  text-transform: none;
+  transition: background-color .2s ease, color .2s ease, border-color .2s ease
+}
+
+.mode-status[data-applied-mode="light"] {
+  color: #013D39;
+  background: rgba(255, 255, 255, .96);
+  border-color: rgba(1, 61, 57, .22)
+}
+
+.mode-status[data-applied-mode="dark"] {
+  color: rgba(244, 255, 253, .95);
+  background: rgba(255, 255, 255, .14);
+  border-color: rgba(255, 255, 255, .26)
+}
+
 .header-search {
   display: flex;
   align-items: center;
@@ -930,6 +968,10 @@ nav a {
     gap: .8rem
   }
 
+  .mode-toggle {
+    gap: .45rem
+  }
+
   .blog-card__link {
     flex-direction: column
   }
@@ -948,6 +990,17 @@ nav a {
   .header-actions {
     gap: .7rem;
     flex-wrap: nowrap
+  }
+
+  .mode-toggle {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: .25rem
+  }
+
+  .mode-status {
+    font-size: .68rem;
+    padding: .28rem .56rem
   }
 
   .header-search {
@@ -969,6 +1022,13 @@ nav a {
 
   .header-search.header-search--expanded .site-search {
     transform: translate(-50%, 0)
+  }
+}
+
+@media (max-width:480px) {
+  .mode-status {
+    white-space: normal;
+    text-align: left
   }
 }
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -149,20 +149,23 @@
         <a itemprop="url" href="/#kontak"><span itemprop="name">Kontak</span></a>
       </nav>
       <div class="header-actions">
-        <button id="darkModeToggle" class="btn btn-gold btn-icon" aria-label="Toggle dark mode" title="Toggle dark mode">
-          <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="5" />
-            <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
-          </svg>
-          <svg class="moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-          </svg>
-          <svg class="auto-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
-            <line x1="8" y1="21" x2="16" y2="21"></line>
-            <line x1="12" y1="17" x2="12" y2="21"></line>
-          </svg>
-        </button>
+        <div class="mode-toggle">
+          <button id="darkModeToggle" class="btn btn-gold btn-icon" aria-label="Beralih ke mode Terang" aria-pressed="mixed" title="Beralih ke mode Terang">
+            <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="12" cy="12" r="5" />
+              <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+            </svg>
+            <svg class="moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+            </svg>
+            <svg class="auto-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
+              <line x1="8" y1="21" x2="16" y2="21"></line>
+              <line x1="12" y1="17" x2="12" y2="21"></line>
+            </svg>
+          </button>
+          <span id="colorModeStatus" class="mode-status" role="status" aria-live="polite" aria-atomic="true">Mode: Otomatis</span>
+        </div>
         <div class="header-search" data-header-search>
           <button class="btn btn-gold btn-icon site-search-toggle" type="button" aria-label="Buka pencarian" aria-expanded="false" aria-controls="headerSearchInput" data-search-toggle data-close-label="Tutup pencarian">
             <svg class="site-search-toggle__icon site-search-toggle__icon--open" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/harga/index.html
+++ b/harga/index.html
@@ -86,20 +86,23 @@
         <a itemprop="url" href="/#kontak"><span itemprop="name">Kontak</span></a>
       </nav>
       <div class="header-actions">
-        <button id="darkModeToggle" class="btn btn-gold btn-icon" aria-label="Toggle dark mode" title="Toggle dark mode">
-          <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="5" />
-            <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
-          </svg>
-          <svg class="moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-          </svg>
-          <svg class="auto-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
-            <line x1="8" y1="21" x2="16" y2="21"></line>
-            <line x1="12" y1="17" x2="12" y2="21"></line>
-          </svg>
-        </button>
+        <div class="mode-toggle">
+          <button id="darkModeToggle" class="btn btn-gold btn-icon" aria-label="Beralih ke mode Terang" aria-pressed="mixed" title="Beralih ke mode Terang">
+            <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="12" cy="12" r="5" />
+              <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+            </svg>
+            <svg class="moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+            </svg>
+            <svg class="auto-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
+              <line x1="8" y1="21" x2="16" y2="21"></line>
+              <line x1="12" y1="17" x2="12" y2="21"></line>
+            </svg>
+          </button>
+          <span id="colorModeStatus" class="mode-status" role="status" aria-live="polite" aria-atomic="true">Mode: Otomatis</span>
+        </div>
         <div class="header-search" data-header-search>
           <button class="btn btn-gold btn-icon site-search-toggle" type="button" aria-label="Buka pencarian" aria-expanded="false" aria-controls="headerSearchInput" data-search-toggle data-close-label="Tutup pencarian">
             <svg class="site-search-toggle__icon site-search-toggle__icon--open" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/index.html
+++ b/index.html
@@ -112,20 +112,23 @@
         <a itemprop="url" href="#kontak"><span itemprop="name">Kontak</span></a>
       </nav>
       <div class="header-actions">
-        <button id="darkModeToggle" class="btn btn-gold btn-icon" aria-label="Toggle dark mode" title="Toggle dark mode">
-          <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="5" />
-            <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
-          </svg>
-          <svg class="moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-          </svg>
-          <svg class="auto-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
-            <line x1="8" y1="21" x2="16" y2="21"></line>
-            <line x1="12" y1="17" x2="12" y2="21"></line>
-          </svg>
-        </button>
+        <div class="mode-toggle">
+          <button id="darkModeToggle" class="btn btn-gold btn-icon" aria-label="Beralih ke mode Terang" aria-pressed="mixed" title="Beralih ke mode Terang">
+            <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="12" cy="12" r="5" />
+              <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+            </svg>
+            <svg class="moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+            </svg>
+            <svg class="auto-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
+              <line x1="8" y1="21" x2="16" y2="21"></line>
+              <line x1="12" y1="17" x2="12" y2="21"></line>
+            </svg>
+          </button>
+          <span id="colorModeStatus" class="mode-status" role="status" aria-live="polite" aria-atomic="true">Mode: Otomatis</span>
+        </div>
         <div class="header-search" data-header-search>
           <button class="btn btn-gold btn-icon site-search-toggle" type="button" aria-label="Buka pencarian" aria-expanded="false" aria-controls="headerSearchInput" data-search-toggle data-close-label="Tutup pencarian">
             <svg class="site-search-toggle__icon site-search-toggle__icon--open" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">


### PR DESCRIPTION
## Summary
- add a dedicated mode-status indicator and dynamic aria attributes to the theme toggle across the main headers
- style the indicator so it remains readable on desktop and mobile breakpoints in both light and dark appearances
- extend the dark mode script to sync aria state, tooltip copy, and indicator text while respecting prefers-color-scheme

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e374b2eafc8330940845f9276e9765