### PR TITLE
Address audit findings for fonts, GTM loader, and offline tracking

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,10 @@
+# Code Review
+
+## 1. Inter bold font points to the regular file
+The self-hosted font declarations map both the 400 and 700 weights of Inter to the exact same WOFF2 asset. As a result, text styled with `font-weight: 700` will render using the regular face, so headings and emphasized copy will not look bold. Ship the actual bold cut (or a variable font slice) and reference it in the 700-weight `@font-face` block so that typographic hierarchy is preserved.【F:assets/css/fonts.css†L1-L7】
+
+## 2. GTM loader executes before the encoding is declared
+Several pages insert `<script src="/assets/js/gtm-loader.js"></script>` ahead of `<meta charset="utf-8">`. The HTML standard expects the charset declaration to appear first so that the parser knows how to decode everything that follows. Loading a blocking script before the charset can force browsers to assume a fallback encoding and delays first paint. Move the charset to the top (before any script) and add `defer` to the GTM loader so it no longer blocks rendering.【F:harga/index.html†L4-L19】
+
+## 3. Offline WA click tracking points at a missing endpoint
+When WhatsApp CTAs are clicked while offline, the service worker registers a background sync that later calls `/track?...` to record the event, and the main bundle can optionally fire the same URL via `navigator.sendBeacon`. This repository only contains static assets, so `/track` resolves to a 404 on typical static hosting, meaning the sync never reports anything and just wastes retries. Either provide a backend endpoint or guard this feature so it is only enabled when the tracking endpoint exists.【F:sw.js†L350-L361】【F:assets/js/main.js†L4537-L4558】【20dd18†L1-L4】

--- a/assets/css/fonts.css
+++ b/assets/css/fonts.css
@@ -2,6 +2,6 @@
 /* Inter Regular (latin) */
 @font-face { font-family:'Inter'; font-style:normal; font-weight:400; font-display:swap; src:url('../fonts/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7.woff2') format('woff2'); unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
 /* Inter Bold (latin) */
-@font-face { font-family:'Inter'; font-style:normal; font-weight:700; font-display:swap; src:url('../fonts/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7.woff2') format('woff2'); unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
+@font-face { font-family:'Inter'; font-style:normal; font-weight:700; font-display:swap; src:url('../fonts/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa25L7SUc.woff2') format('woff2'); unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
 /* Playfair Display Semibold (latin) */
 @font-face { font-family:'Playfair Display'; font-style:normal; font-weight:600; font-display:swap; src:url('../fonts/nuFiD-vYSZviVYUb_rj3ij__anPXDTzYgA.woff2') format('woff2'); unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -4515,6 +4515,9 @@ window.addEventListener('resize', function() {
 /* istanbul ignore next */
 (function() {
   const ENABLE_BEACON = false;
+  const TRACK_ENDPOINT = typeof window !== 'undefined' && typeof window.SENTRALEM_TRACK_ENDPOINT === 'string' && window.SENTRALEM_TRACK_ENDPOINT.trim().length
+    ? window.SENTRALEM_TRACK_ENDPOINT
+    : null;
 
   function track(evt, label) {
     try {
@@ -4538,7 +4541,7 @@ window.addEventListener('resize', function() {
     el.addEventListener('click', function() {
       var label = el.getAttribute('data-track');
       track('cta_click', label);
-      if (label && label.indexOf('wa-') === 0 && 'serviceWorker' in navigator) {
+      if (label && label.indexOf('wa-') === 0 && TRACK_ENDPOINT && 'serviceWorker' in navigator) {
         try {
           navigator.serviceWorker.ready.then(function(reg) {
             var tag = 'wa-click:' + label + ':' + Date.now();
@@ -4548,7 +4551,7 @@ window.addEventListener('resize', function() {
             /* istanbul ignore next */
             if (ENABLE_BEACON && navigator.sendBeacon) {
               try {
-                navigator.sendBeacon('/track', new Blob([JSON.stringify({
+                navigator.sendBeacon(TRACK_ENDPOINT, new Blob([JSON.stringify({
                   e: 'wa',
                   label: label,
                   t: Date.now()

--- a/blog/panduan-buyback-berlian/index.html
+++ b/blog/panduan-buyback-berlian/index.html
@@ -2,11 +2,11 @@
 <html lang="id">
 
 <head>
-  <!-- Google Tag Manager -->
-  <script src="/assets/js/gtm-loader.js"></script>
-  <!-- End Google Tag Manager -->
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Google Tag Manager -->
+  <script src="/assets/js/gtm-loader.js" defer></script>
+  <!-- End Google Tag Manager -->
   <meta http-equiv="Content-Security-Policy" content="default-src 'self';
         img-src 'self' data: https://www.google-analytics.com https://www.googletagmanager.com https://www.google.com https://www.google.co.id https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net;
         media-src 'self';

--- a/harga/index.html
+++ b/harga/index.html
@@ -2,11 +2,11 @@
 <html lang="id">
 
 <head>
-  <!-- Google Tag Manager -->
-  <script src="/assets/js/gtm-loader.js"></script>
-  <!-- End Google Tag Manager -->
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- Google Tag Manager -->
+  <script src="/assets/js/gtm-loader.js" defer></script>
+  <!-- End Google Tag Manager -->
   <meta http-equiv="Content-Security-Policy" content="default-src 'self';
         img-src 'self' data: https://www.google-analytics.com https://www.googletagmanager.com https://www.google.com https://www.google.co.id https://stats.g.doubleclick.net https://www.googleadservices.com https://googleads.g.doubleclick.net;
         media-src 'self';

--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
   <link rel="preload" href="assets/css/styles.css" as="style">
   <link rel="preload" href="assets/css/fonts.css" as="style">
   <link rel="preload" href="assets/fonts/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="assets/fonts/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa25L7SUc.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="preload" href="assets/fonts/nuFiD-vYSZviVYUb_rj3ij__anPXDTzYgA.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="assets/css/fonts.css">
   <link rel="stylesheet" href="assets/css/styles.css">
@@ -1525,7 +1526,7 @@
     }
   </script>
   <!-- Google Tag Manager -->
-  <script src="/assets/js/gtm-loader.js"></script>
+  <script src="/assets/js/gtm-loader.js" defer></script>
   <!-- End Google Tag Manager -->
   <script src="assets/js/main.js" defer></script>
 </body>

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,8 @@
 /* Sentral Emas – Service Worker (subfolder-friendly) */
-const CACHE_NAME = 'sentralemas-v29';
-const FONT_CACHE = 'sentralemas-fonts-v2';
+const CACHE_NAME = 'sentralemas-v30';
+const FONT_CACHE = 'sentralemas-fonts-v3';
+const rawTrackEndpoint = (typeof self !== 'undefined' && 'SENTRALEM_TRACK_ENDPOINT' in self) ? self.SENTRALEM_TRACK_ENDPOINT : null;
+const TRACK_ENDPOINT = typeof rawTrackEndpoint === 'string' && rawTrackEndpoint.trim().length ? rawTrackEndpoint : null;
 
 // Core assets gunakan path relatif terhadap scope
 const CORE_ASSETS = [
@@ -11,6 +13,7 @@ const CORE_ASSETS = [
     './assets/css/styles.css',
     './assets/css/fonts.css',
     './assets/fonts/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7.woff2',
+    './assets/fonts/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa25L7SUc.woff2',
     './assets/fonts/nuFiD-vYSZviVYUb_rj3ij__anPXDTzYgA.woff2',
     './assets/js/main.js',
     './assets/img/logo.webp?v=1',
@@ -349,12 +352,17 @@ self.addEventListener('fetch', (event) => {
 
 // ===== Background Sync untuk klik WA
 self.addEventListener('sync', (event) => {
+    if (!TRACK_ENDPOINT) return;
     if (!event.tag || !event.tag.startsWith('wa-click:')) return;
     event.waitUntil((async () => {
         try {
             const parts = event.tag.split(':'); // ['wa-click', 'label', 'ts']
             const label = parts[1] || 'wa';
-            await fetch(`/track?e=wa&label=${encodeURIComponent(label)}&t=${Date.now()}`, {
+            const trackUrl = new URL(TRACK_ENDPOINT, location.origin);
+            trackUrl.searchParams.set('e', 'wa');
+            trackUrl.searchParams.set('label', label);
+            trackUrl.searchParams.set('t', Date.now().toString());
+            await fetch(trackUrl.toString(), {
                 method: 'GET',
                 credentials: 'omit'
             });


### PR DESCRIPTION
## Summary
- point the Inter 700-weight face to its dedicated WOFF2 file and preload/cache it
- move the GTM loader behind the charset declaration and load it with defer
- gate WhatsApp offline tracking on a configured endpoint and bump the service worker cache version

## Testing
- not run (static site changes)

------
https://chatgpt.com/codex/tasks/task_e_68e3b36501e88330a08ea36f5e078dc0